### PR TITLE
Updated gulp-git to version 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dedent": "0.4.0",
     "glob": "5.0.14",
     "gulp": "3.9.0",
-    "gulp-git": "1.4.0",
+    "gulp-git": "1.5.0",
     "inquirer": "0.10.1",
     "minimist": "1.2.0",
     "strip-json-comments": "1.0.4",


### PR DESCRIPTION
:rocket:

gulp-git just published version 1.5.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 2 commits (ahead by 2, behind by 0).

- [b3eecfe](https://github.com/stevelacy/gulp-git/commit/b3eecfe2e5c039020a7e5ff67ba68bf19c613498): 1.5.0
- [0279463](https://github.com/stevelacy/gulp-git/commit/0279463bee89b18087d2ff922bcb3dc45f374a78): Added support for git clean

See the [full diff](https://github.com/stevelacy/gulp-git/compare/3ab4eebf1967e552e5284d837dcfbedb68e10dfe...b3eecfe2e5c039020a7e5ff67ba68bf19c613498).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>