### PR TITLE
Use only file names when determining if the staging area is clean

### DIFF
--- a/src/commitizen/staging.js
+++ b/src/commitizen/staging.js
@@ -7,11 +7,11 @@ export {isClean};
  * Asynchrounously determines if the staging area is clean
  */
 function isClean(repoPath, done) {
-  git.exec({cwd:repoPath, args: '--no-pager diff --cached', quiet: true}, function (err, stdout) {
+  git.exec({cwd:repoPath, args: '--no-pager diff --cached --name-only', quiet: true}, function (err, stdout) {
     let stagingIsClean;
     if(stdout && isString(stdout) && stdout.trim().length>0)
     {
-      stagingIsClean = false;  
+      stagingIsClean = false;
     } else {
       stagingIsClean = true;
     }


### PR DESCRIPTION
When there is a huge diff we got an error related to reach of maximum stack size. As a way of fix
this issue I suggest to use only names of staged files instead of whole diff.

Is it ok? 

