### PR TITLE
style(front-door): add missing 'n' to the command used to init commit…

### DIFF
--- a/src/cli/commitizen.js
+++ b/src/cli/commitizen.js
@@ -53,7 +53,7 @@ function bootstrap(environment = {}) {
     contributors to follow your commit message conventions using commitizen then
     you'll need to run a command like this one to add this adapter to your config:
         
-         commitizen init cz-convetional-changelog --save
+         commitizen init cz-conventional-changelog --save
         
     You should swap out cz-conventional-changelog for the NPM package name of the
     adapter you wish you install in your project's package.json.


### PR DESCRIPTION
…izen in the help

it's very helpful to just copy to command used to initialize commitizen, but very annoying to keep
adding the missing 'n' each time