### PR TITLE
Pre-compiled Commitizen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules/
 .tmp/
 coverage/
 artifacts/
+/dist
 npm-debug.log

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+/meta
+/src
+/test

--- a/bin/commitizen
+++ b/bin/commitizen
@@ -1,6 +1,3 @@
 #!/usr/bin/env node
 
-require("babel/register")({
-	ignore: /node_modules\/(?!commitizen)/
-});
 require('./commitizen.js');

--- a/bin/commitizen.js
+++ b/bin/commitizen.js
@@ -1,2 +1,2 @@
 
-require('../src/cli/commitizen.js').bootstrap();
+require('../dist/cli/commitizen.js').bootstrap();

--- a/bin/git-cz
+++ b/bin/git-cz
@@ -1,6 +1,3 @@
 #!/usr/bin/env node
 
-require("babel/register")({
-	ignore: /node_modules\/(?!commitizen)/
-});
 require('./git-cz.js');

--- a/bin/git-cz.js
+++ b/bin/git-cz.js
@@ -1,5 +1,4 @@
-require("babel/register");
 var path = require('path');
-require('../src/cli/git-cz.js').bootstrap({
+require('../dist/cli/git-cz.js').bootstrap({
   cliPath: path.join(__dirname, '../')
 });

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "check-coverage": "istanbul check-coverage --statements 80 --branches 80 --functions 80 --lines 80 ",
     "commit": "git-cz",
     "build": "babel src --out-dir dist",
+    "build:watch": "babel --watch src --out-dir dist",
     "prepublish": "npm run build",
     "report-coverage": "cat ./coverage/lcov.info | codecov",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "check-coverage": "istanbul check-coverage --statements 80 --branches 80 --functions 80 --lines 80 ",
     "commit": "git-cz",
+    "build": "babel src --out-dir dist",
+    "prepublish": "npm run build",
     "report-coverage": "cat ./coverage/lcov.info | codecov",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
     "start": "npm run test:watch",

--- a/src/cli/parsers/commitizen.js
+++ b/src/cli/parsers/commitizen.js
@@ -1,6 +1,6 @@
 import minimist from 'minimist';
 
-import { isString, isArray } from '../../../common/util';
+import { isString, isArray } from '../../common/util';
 
 export {
   parse

--- a/src/cli/parsers/git-cz.js
+++ b/src/cli/parsers/git-cz.js
@@ -1,6 +1,6 @@
 import minimist from 'minimist';
 
-import { isString, isArray } from '../../../common/util';
+import { isString, isArray } from '../../common/util';
 
 export {
   parse

--- a/src/cli/strategies/git-cz.js
+++ b/src/cli/strategies/git-cz.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import sh from 'shelljs';
 import inquirer from 'inquirer';
-import {getParsedPackageJsonFromPath} from '../../../common/util';
+import {getParsedPackageJsonFromPath} from '../../common/util';
 import {gitCz as gitCzParser, commitizen as commitizenParser} from '../parsers';
 import {commit, staging, adapter} from '../../commitizen';
 import {addPath} from '../../git';

--- a/src/commitizen/adapter.js
+++ b/src/commitizen/adapter.js
@@ -2,7 +2,7 @@ import path from 'path';
 import fs from 'fs';
 import findNodeModules from 'find-node-modules';
 
-import {isFunction} from '../../common/util';
+import {isFunction} from '../common/util';
 
 export {
   addPathToAdapterConfig,

--- a/src/commitizen/init.js
+++ b/src/commitizen/init.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import * as configLoader from './configLoader';
-import {executeShellCommand} from '../../common/util'; 
+import {executeShellCommand} from '../common/util';
 import * as adapter from './adapter';
 
 let {

--- a/src/commitizen/staging.js
+++ b/src/commitizen/staging.js
@@ -1,5 +1,5 @@
 import git from 'gulp-git';
-import {isString} from '../../common/util';
+import {isString} from '../common/util';
 
 export {isClean};
 

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -16,7 +16,7 @@ export {
  */
 function executeShellCommand(sh, path, installCommand) {
   sh.cd(path);
-  sh.exec(installCommand); 
+  sh.exec(installCommand);
 }
 
 /**
@@ -53,7 +53,7 @@ function isArray(arr) {
 }
 
 /**
- * Test if the passed argument is a function 
+ * Test if the passed argument is a function
  */
 function isFunction(functionToCheck) {
   if(typeof functionToCheck === "undefined")
@@ -63,7 +63,7 @@ function isFunction(functionToCheck) {
     return false;
   } else {
     var getType = {};
-    return functionToCheck && getType.toString.call(functionToCheck) === '[object Function]'; 
+    return functionToCheck && getType.toString.call(functionToCheck) === '[object Function]';
   }
 }
 
@@ -80,4 +80,3 @@ function isString(str) {
     return Object.prototype.toString.call(str) == '[object String]';
   }
 }
-

--- a/src/git/commit.js
+++ b/src/git/commit.js
@@ -1,7 +1,7 @@
 import git from 'gulp-git';
 import gulp from 'gulp';
 import dedent from 'dedent';
-import {isString} from '../../common/util';
+import {isString} from '../common/util';
 
 export { commit };
 

--- a/test/tester.js
+++ b/test/tester.js
@@ -1,7 +1,7 @@
 import * as repo from './tools/repo';
 import * as clean from './tools/clean';
 import * as files from './tools/files';
-import * as util from '../common/util';
+import * as util from '../src/common/util';
 import {config as userConfig} from './config';
 import * as sh from 'shelljs'; // local instance
 import _ from 'lodash';

--- a/test/tests/adapter.js
+++ b/test/tests/adapter.js
@@ -7,7 +7,7 @@ import fs from 'fs';
 // in the short term
 import {adapter, init as commitizenInit} from '../../src/commitizen';
 
-import {isFunction} from '../../common/util';
+import {isFunction} from '../../src/common/util';
 
 // Bootstrap our tester
 import {bootstrap} from '../tester';

--- a/test/tests/util.js
+++ b/test/tests/util.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {isArray, isFunction, isString} from '../../common/util';
+import {isArray, isFunction, isString} from '../../src/common/util';
 
 describe('common util', function() {
   


### PR DESCRIPTION
###### Compiling the `src` folder to `dist` and referring the `bin` files to `dist` instead.

I also added a `.npmignore` file to ignore the `src` folder (among `test` and `meta`) when publishing the package.

This is kind of hard to test but the scripts inside the `bin` folder seams to work fine and if something should have gone wrong I think that it should have blown up big times since I removed `require('babel/register')` from the `bin` folder.

See issue #39 and #51.
