### PR TITLE
docs(cli):  Rename reference to czConfig

### DIFF
--- a/src/cli/commitizen.js
+++ b/src/cli/commitizen.js
@@ -65,7 +65,7 @@ function bootstrap(environment = {}) {
          init <adapter-npm-name> [args]
         
            description: Install a commitizen adapter from npm and adds it to your
-                        czConfig in your package.json file.
+                        config.commitizen in your package.json file.
         
            args:
              --save         Install the adapter to package.json dependencies 


### PR DESCRIPTION
The init sub-command doesn't use czConfig anymore but config.commitizen