### PR TITLE
Move dependencies to devDependencies where possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,30 +47,30 @@
   "license": "MIT",
   "devDependencies": {
     "axios": "0.7.0",
+    "babel": "5.8.34",
     "chai": "3.4.1",
     "codecov.io": "0.1.6",
     "ghooks": "1.0.0",
+    "gulp": "3.9.0",
+    "gulp-git": "1.6.0",
     "istanbul": "0.3.22",
     "mocha": "2.3.4",
-    "semantic-release": "^4.3.5"
+    "node-uuid": "1.4.7",
+    "nodemon": "1.8.1",
+    "rimraf": "2.4.3",
+    "semantic-release": "^4.3.5",
+    "semver": "5.0.3"
   },
   "dependencies": {
-    "babel": "5.8.34",
     "chalk": "1.1.1",
     "cz-conventional-changelog": "1.1.4",
     "dedent": "0.6.0",
     "detect-indent": "4.0.0",
     "find-node-modules": "1.0.1",
     "glob": "6.0.1",
-    "gulp": "3.9.0",
-    "gulp-git": "1.6.0",
     "inquirer": "0.11.0",
     "lodash": "3.10.1",
     "minimist": "1.2.0",
-    "node-uuid": "1.4.7",
-    "nodemon": "1.8.1",
-    "rimraf": "2.4.3",
-    "semver": "5.0.3",
     "shelljs": "0.5.3",
     "strip-json-comments": "2.0.0"
   }


### PR DESCRIPTION
This moves the dependencies

*  babel
*  gulp
*  gulp-git
*  node-uuid
*  nodemon
*  rimraf
*  semver

from `dependencies` to `devDependencies`,
as they appear to be used only for development and testing.

This should yield faster installs for all users installing cz-cli.