### PR TITLE
feat: support npm module names in commitizen.path config

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,20 @@ The above command does three things for you. It installs the cz-conventional-cha
 ...
   "config": {
     "commitizen": {
-      "path": "node_modules/cz-conventional-changelog"
+      "path": "cz-conventional-changelog"
     }
   }
 ```
 
 This just tells Commitizen which adapter we actually want our contributors to use when they try to commit to this repo.
+
+`commitizen.path` is resolved via [require.resolve](https://nodejs.org/api/globals.html#globals_require_resolve) and supports
+
+*  npm modules
+*  directories relative to `process.cwd()` containing an `index.js` file
+*  file base names relative to `process.cwd()` with `js` extension
+*  full relative file names
+*  absolute paths.
 
 Please note that in previous version of Commitizen we used czConfig. **czConfig has been deprecated** and you should migrate to the new format before Commitizen 3.0.0.
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "dedent": "0.6.0",
     "detect-indent": "4.0.0",
     "find-node-modules": "1.0.1",
+    "find-root": "^1.0.0",
     "glob": "6.0.1",
     "gulp": "3.9.0",
     "gulp-git": "1.6.0",

--- a/test/tests/adapter.js
+++ b/test/tests/adapter.js
@@ -1,6 +1,5 @@
 import {expect} from 'chai';
 import path from 'path';
-import fs from 'fs';
 
 // TODO: augment these tests with tests using the actual cli call
 // For now we're just using the library, which is probably fine
@@ -60,8 +59,8 @@ describe('adapter', function() {
     // TEST 
     expect(function() {adapter.resolveAdapterPath('IAMANIMPOSSIBLEPATH'); }).to.throw(Error);
     expect(function() {adapter.resolveAdapterPath(adapterConfig.path); }).not.to.throw(Error);
-    expect(function() {adapter.resolveAdapterPath(path.join(adapterConfig.path, 'index.js')) }).not.to.throw(Error);
-    
+    expect(function() {adapter.resolveAdapterPath(path.join(adapterConfig.path, 'index.js')); }).not.to.throw(Error);
+    expect(function() {adapter.resolveAdapterPath('cz-conventional-changelog'); }).not.to.throw(Error);
   });
   
   it('gets adapter prompter functions', function(){


### PR DESCRIPTION
This change contains
*   A refactoring of the `adapter.resolveAdapterPath` method

*   An additional test case for the `adapter.resolveAdapterPath` method

*   Updated documentation to reflect the changes

*   Remove unneeded resolving of param passed to getPrompter in git-cz
strategy

*   Use find-root package to determine position of package.json to
determine the path more reliable in complex npm situations

Instead of doing `fs.lsStatSync` calls against `commitizen.path`
`resolveAdapterPath` relies on `require.resolve`, which allows for
support of npm module names in `commitizen.path` while maintaining
backwards compatibility with the former implementation and
documentation.

Closes #79