### PR TITLE
docs(retry): Updated docs to include how to run --retry from a npm script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ npm install -g commitizen
 ```
 
 #### Using the command line tool
-Now, simply use `git cz` instead of `git commit` when committing. 
+Now, simply use `git cz` instead of `git commit` when committing.
 
-When you're working in a Commitizen friendly repository, you'll be prompted to fill in any required fields and your commit messages will be formatted according to the standards defined by project maintainers. 
+When you're working in a Commitizen friendly repository, you'll be prompted to fill in any required fields and your commit messages will be formatted according to the standards defined by project maintainers.
 
 [![Add and commit with Commitizen](https://github.com/commitizen/cz-cli/raw/master/meta/screenshots/add-commit.png)](https://github.com/commitizen/cz-cli/raw/master/meta/screenshots/add-commit.png)
 
 If you're not working in a Commitizen friendly repository, then `git cz` will work just the same as `git commit`.
 
 ### Commitizen for project maintainers
-As a project maintainer, making your repo Commitizen friendly allows you to select pre-existing commit message conventions or to create your own custom commit message convention. When a contributor to your repo uses Commitizen, they will be prompted for the correct fields at commit time. 
+As a project maintainer, making your repo Commitizen friendly allows you to select pre-existing commit message conventions or to create your own custom commit message convention. When a contributor to your repo uses Commitizen, they will be prompted for the correct fields at commit time.
 
 #### Making your repo Commitizen-friendly
 
@@ -84,9 +84,16 @@ Commitizen is great on its own, but it shines when you use it with some other am
 
 #### Retrying failed commits
 
-As of version 2.7.1, you may attempt to retry the last commit using the `git cz --retry` command.  This can be helpful when you have tests set up to run via a git precommit hook.  In this scenario, you may have attempted a Commitizen commit, painstakingly filled out all of the commitizen fields, but your tests fail. In previous Commitizen versions, after fixing your tests, you would be forced to fill out all of the fields again. Enter the retry command. Commitizen will retry the last commit that you attempted in this repo without you needing to fill out the fields again. 
+As of version 2.7.1, you may attempt to retry the last commit using the `git cz --retry` command. This can be helpful when you have tests set up to run via a git precommit hook.  In this scenario, you may have attempted a Commitizen commit, painstakingly filled out all of the commitizen fields, but your tests fail. In previous Commitizen versions, after fixing your tests, you would be forced to fill out all of the fields again. Enter the retry command. Commitizen will retry the last commit that you attempted in this repo without you needing to fill out the fields again.
 
 Please note that the retry cache may be cleared when upgrading commitizen versions, upgrading adapters, or if you delete the `commitizen.json` file in your home or temp directory.  Additionally, the commit cache uses the filesystem path of the repo, so if you move a repo or change its path, you will not be able to retry a commit. This is an edge case, but might be confusing if you have scenarios where you are moving folders that contain repos.
+
+It is important to note that if you are running `git-cz` from a npm script (let's say it is called `commit`) you will need to do one of the following:
+- Pass `-- --retry` as an argument for your script. i.e: `npm run commit -- --retry`
+- Use [npm-run](https://www.npmjs.com/package/npm-run) to find and call git-cz executable directly. i.e: `npm-run git-cz --retry`
+- Use [npm-quick-run](https://www.npmjs.com/package/npm-quick-run) i.e: `nr commit --retry` or just `nr c --retry` (which will run all scripts that starts with the letter 'c')
+
+Note that the last two options **do not** require you to pass `--` before the args but the first **does**.
 
 ### Adapters
 
@@ -117,4 +124,3 @@ We accomplish this by letting you define which adapter you'd like to use in your
 @Den-dp
 
 Special thanks to @stevelacy, whose [gulp-git](https://www.npmjs.com/package/gulp-git) project makes commitizen possible.
-


### PR DESCRIPTION
To run git-cz with the --retry option from a npm script we need to do: 'npm run -- --retry'

references #132