### PR TITLE
fix(commit): allow quotes in commit message

### DIFF
--- a/src/git/commit.js
+++ b/src/git/commit.js
@@ -13,13 +13,14 @@ function commit(sh, repoPath, message, options, done) {
 
   var alreadyEnded = false;
   let dedentedMessage = dedent(message);
+  let escapedMessage = dedentedMessage.replace(/"/g, '\\"');
   let operatingSystemNormalizedMessage;
   // On windows we must use an array in gulp-git instead of a string because
   // command line parsing works differently
   if(os.platform()=="win32") {
-    operatingSystemNormalizedMessage = dedentedMessage.split(/\r?\n/);
+    operatingSystemNormalizedMessage = escapedMessage.split(/\r?\n/);
   } else {
-    operatingSystemNormalizedMessage = dedentedMessage;
+    operatingSystemNormalizedMessage = escapedMessage;
   }
   
   // Get a gulp stream based off the config

--- a/test/tests/commit.js
+++ b/test/tests/commit.js
@@ -74,6 +74,51 @@ describe('commit', function() {
 
   });
   
+  it('should commit message with quotes', function(done) {
+
+    this.timeout(config.maxTimeout); // this could take a while
+
+    // SETUP
+
+    let dummyCommitMessage = `sip sip sippin' on some "sizzurp"`;
+
+    // Describe a repo and some files to add and commit
+    let repoConfig = {
+      path: config.paths.endUserRepo,
+      files: {
+        dummyfile: {
+            contents: `duck-duck-goose`,
+            filename: `mydummyfile.txt`,
+        },
+        gitignore: {
+          contents: `node_modules/`,
+          filename: `.gitignore`
+        }
+      }
+    };
+
+    // Describe an adapter
+    let adapterConfig = {
+      path: path.join(repoConfig.path, '/node_modules/cz-jira-smart-commit'),
+      npmName: 'cz-jira-smart-commit'
+    };
+
+    // Quick setup the repos, adapter, and grab a simple prompter
+    let prompter = quickPrompterSetup(sh, repoConfig, adapterConfig, dummyCommitMessage);
+    // TEST
+
+    // Pass in inquirer but it never gets used since we've mocked out a different
+    // version of prompter.
+    commitizenCommit(sh, inquirer, repoConfig.path, prompter, {disableAppendPaths:true, quiet:true, emitData:true}, function() {
+      log(repoConfig.path, function(logOutput) {
+        expect(logOutput).to.have.string(dummyCommitMessage);
+        done();
+      });
+    });
+
+  });
+
+  
   it('should commit multiline messages', function(done) {
     
     this.timeout(config.maxTimeout); // this could take a while


### PR DESCRIPTION
Fixes an issue in which quotes in the description were not escaped and would cause cz to fail.

```shell
? Provide a longer description of the change:
 Adds "Boaty McBoatface" to the list of contributors.
```

Would result in:
```
error: pathspec 'McBoatface' did not match any file(s) known to git.
{ [Error: Command failed: git commit -m "fix(commit): fix stuff

 Adds "Boaty McBoatface" to the list of contributors.
error: pathspec 'McBoatface' did not match any file(s) known to git.
]
  killed: false,
  code: 1,
  signal: null,
  cmd: 'git commit -m "fix(commit): fix stuff\n\nFixes integer overflow caused by "Boaty McBoatface""  ' }
```

This PR should take care of the issue by ensuring quotes are escaped before they're passed to git.