### PR TITLE
fix(commit): allow backticks in commit message

### DIFF
--- a/src/git/commit.js
+++ b/src/git/commit.js
@@ -13,7 +13,7 @@ function commit(sh, repoPath, message, options, done) {
 
   var alreadyEnded = false;
   let dedentedMessage = dedent(message);
-  let escapedMessage = dedentedMessage.replace(/"/g, '\\"');
+  let escapedMessage = dedentedMessage.replace(/"/g, '\\"').replace(/`/g, '\\`');
   let operatingSystemNormalizedMessage;
   // On windows we must use an array in gulp-git instead of a string because
   // command line parsing works differently

--- a/test/tests/commit.js
+++ b/test/tests/commit.js
@@ -80,7 +80,7 @@ describe('commit', function() {
 
     // SETUP
 
-    let dummyCommitMessage = `sip sip sippin' on some "sizzurp"`;
+    let dummyCommitMessage = `sip \`sip\` sippin' on some "sizzurp"`;
 
     // Describe a repo and some files to add and commit
     let repoConfig = {
@@ -118,7 +118,7 @@ describe('commit', function() {
 
   });
 
-  
+
   it('should commit multiline messages', function(done) {
     
     this.timeout(config.maxTimeout); // this could take a while


### PR DESCRIPTION
Escapes backticks before passing the commit message to Git.

Closes #105