### PR TITLE
fix(commit): does not try to escape backticks on Windows

### DIFF
--- a/src/git/commit.js
+++ b/src/git/commit.js
@@ -13,14 +13,14 @@ function commit(sh, repoPath, message, options, done) {
 
   var alreadyEnded = false;
   let dedentedMessage = dedent(message);
-  let escapedMessage = dedentedMessage.replace(/"/g, '\\"').replace(/`/g, '\\`');
+  let escapedMessage = dedentedMessage.replace(/"/g, '\\"');
   let operatingSystemNormalizedMessage;
   // On windows we must use an array in gulp-git instead of a string because
   // command line parsing works differently
   if(os.platform()=="win32") {
     operatingSystemNormalizedMessage = escapedMessage.split(/\r?\n/);
   } else {
-    operatingSystemNormalizedMessage = escapedMessage;
+    operatingSystemNormalizedMessage = escapedMessage.replace(/`/g, '\\`');
   }
   
   // Get a gulp stream based off the config


### PR DESCRIPTION
fixes previous commit, which should only have applied to *nix

Closes #105