### PR TITLE
add ability to load adapterConfig from bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,9 +58,11 @@
     "node-uuid": "1.4.7",
     "nodemon": "1.9.1",
     "nyc": "6.1.1",
+    "proxyquire": "^1.7.4",
     "rimraf": "2.5.2",
     "semantic-release": "^4.3.5",
-    "semver": "5.1.0"
+    "semver": "5.1.0",
+    "sinon": "^1.17.3"
   },
   "dependencies": {
     "chalk": "1.1.3",
@@ -83,6 +85,13 @@
     "presets": [
       "es2015",
       "stage-2"
+    ]
+  },
+
+  "nyc": {
+    "exclude": [
+      "src/cli",
+      "test"
     ]
   }
 }

--- a/src/cli/git-cz.js
+++ b/src/cli/git-cz.js
@@ -14,10 +14,9 @@ function bootstrap(environment = {}) {
 
   // Get cli args
   let rawGitArgs = process.argv.slice(2, process.argv.length);
-  
-  // Load the adapter config
-  let adapterConfig = configLoader.load();
-  
+
+  let adapterConfig = environment.config || configLoader.load();
+
   // Choose a strategy based on the existance the adapter config
   if(typeof adapterConfig !== 'undefined') {
     // This tells commitizen we're in business

--- a/test/tests/cli.js
+++ b/test/tests/cli.js
@@ -1,0 +1,59 @@
+import {expect} from 'chai';
+import proxyquire from 'proxyquire';
+import * as sinon from 'sinon';
+
+describe('git-cz', () => {
+  let bootstrap;
+  let fakeStrategies, fakeCommitizen;
+
+  beforeEach(() => {
+    fakeStrategies = {
+      git: sinon.spy(),
+      gitCz: sinon.spy()
+    }
+
+    fakeCommitizen = {
+      configLoader: {
+        load: sinon.stub()
+      }
+    }
+
+    bootstrap = proxyquire('../../src/cli/git-cz', {
+      './strategies': fakeStrategies,
+      '../commitizen': fakeCommitizen
+    }).bootstrap;
+  });
+
+  describe('bootstrap', () => {
+    describe('when config is provided', () => {
+      it('passes config to useGitCzStrategy', () => {
+        const config = sinon.spy();
+
+        bootstrap({ config });
+
+        expect(fakeStrategies.gitCz.args[0][2]).to.equal(config);
+      });
+    });
+
+    describe('when config is not provided', () => {
+
+      describe('and the config is returned from configLoader.load', () => {
+        it('uses config from configLoader.load()', () => {
+          const config = sinon.stub();
+          fakeCommitizen.configLoader.load.returns(config);
+
+          bootstrap({});
+
+          expect(fakeStrategies.gitCz.args[0][2]).to.equal(config);
+        });
+      });
+
+      describe('and the config is not returned from configLoader.load', () => {
+        it('tells commitizen to use the git strategy', () => {
+          bootstrap({});
+          expect(fakeStrategies.git.called).to.equal(true);
+        });
+      });
+    });
+  });
+});

--- a/test/tests/index.js
+++ b/test/tests/index.js
@@ -1,4 +1,5 @@
 import './adapter';
+import './cli';
 import './commit';
 import './configLoader';
 import './init';


### PR DESCRIPTION
Instead of forcing the commitizen config to be loaded via a file (package.json, .czrc, .cz.json)
this adds a way to inject an adapterConfig into the bootstrap function. We use this internally at
Autodesk to wrap the cli so that each of our repos doesn't need to have the commitizen config

For example in our node_module we include a dependency to commitizen and then do the following to pass our config in:

```javascript
"use strict";

const path = require('path');

const bootstrap = require('commitizen/dist/cli/git-cz').bootstrap;
bootstrap({
  cliPath: path.join(__dirname, '../node_modules/commitizen'),
  // this is new
  config: {
    "path": "cz-conventional-changelog"
  }
});
```