### PR TITLE
Add supported engines to package specification

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,5 +92,9 @@
       "src/cli",
       "test"
     ]
+  },
+  "engineStrict": true,
+  "engines": {
+    "node": ">= 0.12"
   }
 }


### PR DESCRIPTION
As discussed in #226, this prevents installation when running Node 0.10