### PR TITLE
chore: remove gulp-git dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,8 +73,6 @@
     "find-node-modules": "1.0.3",
     "find-root": "1.0.0",
     "glob": "7.0.5",
-    "gulp": "3.9.1",
-    "gulp-git": "1.7.2",
     "home-or-tmp": "2.0.0",
     "inquirer": "1.0.3",
     "lodash": "4.11.1",

--- a/src/cli/strategies/git-cz.js
+++ b/src/cli/strategies/git-cz.js
@@ -47,20 +47,31 @@ function gitCz(rawGitArgs, environment, adapterConfig) {
   let resolvedAdapterRootPath = findRoot(resolvedAdapterConfigPath);
   let prompter = getPrompter(adapterConfig.path);
 
-  isClean(process.cwd(), function(stagingIsClean){
-    if(stagingIsClean) {
-      console.error('Error: No files added to staging! Did you forget to run git add?')
-    } else {
-      // OH GOD IM SORRY FOR THIS SECTION
-      let adapterPackageJson = getParsedPackageJsonFromPath(resolvedAdapterRootPath);
-      let cliPackageJson = getParsedPackageJsonFromPath(environment.cliPath);
-      console.log(`cz-cli@${cliPackageJson.version}, ${adapterPackageJson.name}@${adapterPackageJson.version}\n`);
-      commit(sh, inquirer, process.cwd(), prompter, {args: parsedGitCzArgs, disableAppendPaths:true, emitData:true, quiet:false, retryLastCommit}, function() {
-        // console.log('commit happened');
-      });
-      
+  isClean(process.cwd(), function(error, stagingIsClean){
+    if (error) {
+      throw error;
     }
+
+    if(stagingIsClean) {
+      throw new Error('No files added to staging! Did you forget to run git add?');
+    }
+
+    // OH GOD IM SORRY FOR THIS SECTION
+    let adapterPackageJson = getParsedPackageJsonFromPath(resolvedAdapterRootPath);
+    let cliPackageJson = getParsedPackageJsonFromPath(environment.cliPath);
+    console.log(`cz-cli@${cliPackageJson.version}, ${adapterPackageJson.name}@${adapterPackageJson.version}\n`);
+    commit(sh, inquirer, process.cwd(), prompter, {
+      args: parsedGitCzArgs,
+      disableAppendPaths:true,
+      emitData:true,
+      quiet:false,
+      retryLastCommit
+    }, function(error) {
+      if (error) {
+        throw error;
+      }
+      // console.log('commit happened');
+    });
   });
-  
 
 }

--- a/src/cli/strategies/git.js
+++ b/src/cli/strategies/git.js
@@ -16,6 +16,7 @@ function git(rawGitArgs, environment) {
 
     child.on('error', function (e, code) {
       console.error(e);
+      throw e;
     });
   }
 }

--- a/src/commitizen/adapter.js
+++ b/src/commitizen/adapter.js
@@ -112,7 +112,7 @@ function getPrompter(adapterPath) {
 
   // Load the adapter
   let adapter = require(resolvedAdapterPath);
-  
+
   if(adapter && adapter.prompter && isFunction(adapter.prompter)) {
      return adapter.prompter;
   } else {

--- a/src/commitizen/staging.js
+++ b/src/commitizen/staging.js
@@ -1,5 +1,4 @@
-import git from 'gulp-git';
-import {isString} from '../common/util';
+import {exec} from 'child_process';
 
 export {isClean};
 
@@ -7,14 +6,14 @@ export {isClean};
  * Asynchrounously determines if the staging area is clean
  */
 function isClean(repoPath, done) {
-  git.exec({cwd:repoPath, args: '--no-pager diff --cached --name-only', quiet: true}, function (err, stdout) {
-    let stagingIsClean;
-    if(stdout && isString(stdout) && stdout.trim().length>0)
-    {
-      stagingIsClean = false;
-    } else {
-      stagingIsClean = true;
+  exec('git diff --cached --name-only', {
+    maxBuffer: Infinity,
+    cwd: repoPath || process.cwd()
+  }, function(error, stdout) {
+    if (error) {
+      return done(error);
     }
-    done(stagingIsClean);
+    let output = stdout || '';
+    done(null, output.trim().length === 0);
   });
 }

--- a/src/git/init.js
+++ b/src/git/init.js
@@ -5,5 +5,5 @@ export { init };
  */
 function init(sh, repoPath) {
   sh.cd(repoPath);
-  sh.exec('git init');    
+  sh.exec('git init');
 }

--- a/src/git/log.js
+++ b/src/git/log.js
@@ -1,4 +1,4 @@
-import git from 'gulp-git';
+import {exec} from 'child_process';
 
 export { log };
 
@@ -6,8 +6,13 @@ export { log };
  * Asynchronously gets the git log output
  */
 function log(repoPath, done) {
-  // Get a gulp stream based off the config
-  git.exec({cwd: repoPath, args: 'log', quiet: true}, function(err, stdout) {
+  exec('git log', {
+    maxBuffer: Infinity,
+    cwd: repoPath
+  }, function(error, stdout, stderr) {
+    if (error) {
+      done();
+    }
     done(stdout);
   });
 }

--- a/test/tests/commit.js
+++ b/test/tests/commit.js
@@ -61,7 +61,7 @@ describe('commit', function() {
     
     // Quick setup the repos, adapter, and grab a simple prompter
     let prompter = quickPrompterSetup(sh, repoConfig, adapterConfig, dummyCommitMessage);
-    // TEST 
+    // TEST
    
     // Pass in inquirer but it never gets used since we've mocked out a different
     // version of prompter.
@@ -128,20 +128,20 @@ describe('commit', function() {
     // Don't trim or delete the spacing in this commit message!
     
     // Git on *nix retains spaces on lines with only spaces
-    // The blank line of this block should have 4 spaces. 
-    let nixCommitMessage = 
+    // The blank line of this block should have 4 spaces.
+    let nixCommitMessage =
     `sip sip sippin on jnkjnkjn
     
     some sizzurp`;
     
     // Git on win32 removes spaces from lines with only spaces
     // The blank line of this block should have no spaces
-    let windowsCommitMessage = 
+    let windowsCommitMessage =
     `sip sip sippin on jnkjnkjn
 
     some sizzurp`;
     
-    let dummyCommitMessage = (os.platform == 'win32') ? windowsCommitMessage : nixCommitMessage; 
+    let dummyCommitMessage = (os.platform == 'win32') ? windowsCommitMessage : nixCommitMessage;
     
     // Describe a repo and some files to add and commit
     let repoConfig = {
@@ -166,7 +166,7 @@ describe('commit', function() {
     
     // Quick setup the repos, adapter, and grab a simple prompter
     let prompter = quickPrompterSetup(sh, repoConfig, adapterConfig, dummyCommitMessage);
-    // TEST 
+    // TEST
    
     // Pass in inquirer but it never gets used since we've mocked out a different
     // version of prompter.
@@ -179,7 +179,7 @@ describe('commit', function() {
 
   });
 
-  it('should allow to override options passed to gulp-git', function(done) {
+  it('should allow to override git commit options', function(done) {
     
     this.timeout(config.maxTimeout); // this could take a while
     
@@ -215,7 +215,7 @@ describe('commit', function() {
     
     // Quick setup the repos, adapter, and grab a simple prompter
     let prompter = quickPrompterSetup(sh, repoConfig, adapterConfig, dummyCommitMessage, options);
-    // TEST 
+    // TEST
    
     // Pass in inquirer but it never gets used since we've mocked out a different
     // version of prompter.
@@ -234,13 +234,13 @@ describe('commit', function() {
 afterEach(function() {
   // All this should do is archive the tmp path to the artifacts
   clean.afterEach(sh, config.paths.tmp, config.preserve);
-}); 
+});
 
 after(function() {
-  // Once everything is done, the artifacts should be cleaned up based on 
+  // Once everything is done, the artifacts should be cleaned up based on
   // the preserve setting in the config
   clean.after(sh, config.paths.tmp, config.preserve);
-}); 
+});
 
 /**
   * This is just a helper for testing. NOTE that prompter
@@ -267,5 +267,5 @@ function quickPrompterSetup(sh, repoConfig, adapterConfig, commitMessage, option
   // NOTE: In the real world we would not be returning
   // this we would instead be just making the commented
   // out getPrompter() call to get user input (above).
-  return prompter; 
+  return prompter;
 }

--- a/test/tests/staging.js
+++ b/test/tests/staging.js
@@ -49,21 +49,25 @@ describe('staging', function() {
     
     gitInit(sh, repoConfig.path);
     
-    staging.isClean(repoConfig.path, function(stagingIsClean) {
-      
-      expect(stagingIsClean).to.be.true;
-      
-      writeFilesToPath(repoConfig.files, repoConfig.path);
-      
-      gitAdd(sh, repoConfig.path);
-      
-      staging.isClean(repoConfig.path, function(afterWriteStagingIsClean) {
-        expect(afterWriteStagingIsClean).to.be.false;
-        done();
+    staging.isClean('./@this-actually-does-not-exist', function(stagingError) {
+      expect(stagingError).to.be.an.instanceof(Error);
+    
+      staging.isClean(repoConfig.path, function(stagingIsCleanError, stagingIsClean) {
+        expect(stagingIsCleanError).to.be.null;
+        expect(stagingIsClean).to.be.true;
+        
+        writeFilesToPath(repoConfig.files, repoConfig.path);
+        
+        gitAdd(sh, repoConfig.path);
+        
+        staging.isClean(repoConfig.path, function(afterWriteStagingIsCleanError, afterWriteStagingIsClean) {
+          expect(afterWriteStagingIsCleanError).to.be.null;
+          expect(afterWriteStagingIsClean).to.be.false;
+          done();
+        });
+        
       });
-      
     });
-
   });
 
 });
@@ -71,10 +75,10 @@ describe('staging', function() {
 afterEach(function() {
   // All this should do is archive the tmp path to the artifacts
   clean.afterEach(sh, config.paths.tmp, config.preserve);
-}); 
+});
 
 after(function() {
-  // Once everything is done, the artifacts should be cleaned up based on 
+  // Once everything is done, the artifacts should be cleaned up based on
   // the preserve setting in the config
   clean.after(sh, config.paths.tmp, config.preserve);
-}); 
+});


### PR DESCRIPTION
*  gets rid of gulp dependency
*  gets rid of gulp-git dependency
*  solves gulp-related deprecation warnings
*  improves install times considerably
*  use child_process.exec for git commands

---
- [x] fix coverage
- [x] fix windows support
- [x] restore cwd switching to `commit` and `log`