### PR TITLE
chore: save npm dependencies with pinned version by default

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact = true

--- a/package.json
+++ b/package.json
@@ -58,11 +58,11 @@
     "node-uuid": "1.4.7",
     "nodemon": "1.9.1",
     "nyc": "6.6.1",
-    "proxyquire": "^1.7.9",
+    "proxyquire": "1.7.9",
     "rimraf": "2.5.2",
-    "semantic-release": "^4.3.5",
+    "semantic-release": "4.3.5",
     "semver": "5.1.0",
-    "sinon": "^1.17.3"
+    "sinon": "1.17.3"
   },
   "dependencies": {
     "chalk": "1.1.3",
@@ -70,7 +70,7 @@
     "dedent": "0.6.0",
     "detect-indent": "4.0.0",
     "find-node-modules": "1.0.1",
-    "find-root": "^1.0.0",
+    "find-root": "1.0.0",
     "glob": "7.0.4",
     "gulp": "3.9.1",
     "gulp-git": "1.7.2",


### PR DESCRIPTION
*  repins all npm dependencies in package.json
*  adds .npmrc with save-exact = true