### PR TITLE
fix(adapter): allows git cz to be run from subdirectories

### DIFF
--- a/src/commitizen/adapter.js
+++ b/src/commitizen/adapter.js
@@ -131,7 +131,7 @@ function resolveAdapterPath(inboundAdapterPath) {
   
   // Resolve from process.cwd() if inboundAdapterPath is a path
   let absoluteAdapterPath = isPath ?
-    path.resolve(process.cwd(), inboundAdapterPath) :
+    path.resolve(getNearestProjectRootDirectory(), inboundAdapterPath) :
     inboundAdapterPath;
   
   try {


### PR DESCRIPTION
looks for the adapter file relative to the project root rather than cwd

closes #187