### PR TITLE
fix: harden adapter callback error handling

### DIFF
--- a/src/cli/strategies/git-cz.js
+++ b/src/cli/strategies/git-cz.js
@@ -62,15 +62,14 @@ function gitCz(rawGitArgs, environment, adapterConfig) {
     console.log(`cz-cli@${cliPackageJson.version}, ${adapterPackageJson.name}@${adapterPackageJson.version}\n`);
     commit(sh, inquirer, process.cwd(), prompter, {
       args: parsedGitCzArgs,
-      disableAppendPaths:true,
-      emitData:true,
-      quiet:false,
+      disableAppendPaths: true,
+      emitData: true,
+      quiet: false,
       retryLastCommit
     }, function(error) {
       if (error) {
         throw error;
       }
-      // console.log('commit happened');
     });
   });
 

--- a/src/commitizen/commit.js
+++ b/src/commitizen/commit.js
@@ -1,4 +1,5 @@
 import path from 'path';
+
 import homeOrTmp from 'home-or-tmp';
 import dedent from 'dedent';
 import {commit as gitCommit, log} from '../git';
@@ -10,12 +11,10 @@ export default commit;
  * Takes all of the final inputs needed in order to make dispatch a git commit
  */
 function dispatchGitCommit(sh, repoPath, template, options, overrideOptions, done) {
-  
     // Commit the user input -- side effect that we'll test
-    gitCommit(sh, repoPath, template, { ...options, ...overrideOptions }, function() {
-      done(template);
+    gitCommit(sh, repoPath, template, { ...options, ...overrideOptions }, function(error) {
+      done(error, template);
     });
-    
 }
 
  /**
@@ -31,7 +30,7 @@ function commit(sh, inquirer, repoPath, prompter, options, done) {
     
     // We want to use the last commit instead of the current commit,
     // so lets override some options using the values from cache.
-    let { 
+    let {
       options: retryOptions,
       overrideOptions: retryOverrideOptions,
       template: retryTemplate
@@ -40,12 +39,23 @@ function commit(sh, inquirer, repoPath, prompter, options, done) {
     
   } else {
     // Get user input -- side effect that is hard to test
-    prompter(inquirer, function(template, overrideOptions) {
-    
+    prompter(inquirer, function(error, template, overrideOptions) {
+      // Allow adapters to error out
+      // (error: Error?, template: String, overrideOptions: Object)
+      if (!(error instanceof Error)) {
+        overrideOptions = template;
+        template = error;
+        error = null;
+      }
+
+      if (error) {
+        return done(error);
+      }
+
       // We don't want to add retries to the cache, only actual commands
       cache.setCacheValueSync(cachePath, repoPath, { template, options, overrideOptions });
       dispatchGitCommit(sh, repoPath, template, options, overrideOptions, done);
-    }); 
+    });
   }
    
 }

--- a/src/git/commit.js
+++ b/src/git/commit.js
@@ -31,6 +31,7 @@ function commit(sh, repoPath, message, options, done) {
     stdio: options.quiet ? 'ignore' : 'inherit'
   }, function(error, stdout, stderror) {
     if (error) {
+      error.message = [error.message, stderror].filter(Boolean).join('\n');
       return done(error);
     }
     done();


### PR DESCRIPTION
*  minor code cleanups (cli/strategies/git-cz.js)
*  pass error as first argument into `dispatchGitCommit` callback
*  handle errors raised by commitizen adapters via optional error argument
*  attach stderr to error message in case of `git commit` errors

Fix #308