### PR TITLE
fix(npmignore): ignore more unnecessary files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,8 @@
 /src
 /test
 test/tools/trigger-appveyor-tests.sh
+/coverage
+/.travis.yml
+/appveyor.yml
+jsconfig.json
+travis_after_all.py


### PR DESCRIPTION
According to [cost-of-modules](https://github.com/siddharthkp/cost-of-modules)
commitizen is responsible for `76.32M` of my disk space. Most of that is
probably from dependencies, but while looking into this, I noticed that
there are several files we should probably not be publishing.