### PR TITLE
feat(commit): use OS-specific cache dir for commitizen.json instead of home-or-tmp

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "nodemon": "1.11.0",
     "nyc": "6.6.1",
     "proxyquire": "1.7.10",
-    "rimraf": "2.5.4",
     "semantic-release": "4.3.5",
     "semver": "5.3.0",
     "sinon": "1.17.6"

--- a/package.json
+++ b/package.json
@@ -66,14 +66,15 @@
     "sinon": "1.17.6"
   },
   "dependencies": {
+    "cachedir": "^1.1.0",
     "chalk": "1.1.3",
     "cz-conventional-changelog": "1.2.0",
     "dedent": "0.6.0",
     "detect-indent": "4.0.0",
     "find-node-modules": "1.0.3",
     "find-root": "1.0.0",
+    "fs-extra": "^1.0.0",
     "glob": "7.1.1",
-    "home-or-tmp": "2.0.0",
     "inquirer": "1.2.2",
     "lodash": "4.16.3",
     "minimist": "1.2.0",

--- a/src/commitizen/commit.js
+++ b/src/commitizen/commit.js
@@ -1,7 +1,8 @@
 import path from 'path';
 
-import homeOrTmp from 'home-or-tmp';
 import dedent from 'dedent';
+import cacheDir from 'cachedir';
+import {ensureDir} from 'fs-extra';
 import {commit as gitCommit, log} from '../git';
 import * as cache from './cache';
 
@@ -21,41 +22,48 @@ function dispatchGitCommit(sh, repoPath, template, options, overrideOptions, don
   * Asynchronously commits files using commitizen
   */
 function commit(sh, inquirer, repoPath, prompter, options, done) {
-  
-  var cachePath = path.join(homeOrTmp, 'commitizen.json');
-  
-  if(options.retryLastCommit) {
-    
-    console.log('Retrying last commit attempt.');
-    
-    // We want to use the last commit instead of the current commit,
-    // so lets override some options using the values from cache.
-    let {
-      options: retryOptions,
-      overrideOptions: retryOverrideOptions,
-      template: retryTemplate
-    } = cache.getCacheValueSync(cachePath, repoPath);
-    dispatchGitCommit(sh, repoPath, retryTemplate, retryOptions, retryOverrideOptions, done);
-    
-  } else {
-    // Get user input -- side effect that is hard to test
-    prompter(inquirer, function(error, template, overrideOptions) {
-      // Allow adapters to error out
-      // (error: Error?, template: String, overrideOptions: Object)
-      if (!(error instanceof Error)) {
-        overrideOptions = template;
-        template = error;
-        error = null;
-      }
+  var cacheDirectory = cacheDir('commitizen');
+  var cachePath = path.join(cacheDirectory, 'commitizen.json');
 
-      if (error) {
-        return done(error);
-      }
+  ensureDir(cacheDirectory, function(error) {
+    if (error) {
+      console.error("Couldn't create commitizen cache directory: ", error);
+      // TODO: properly handle error?
+    } else {
+      if(options.retryLastCommit) {
 
-      // We don't want to add retries to the cache, only actual commands
-      cache.setCacheValueSync(cachePath, repoPath, { template, options, overrideOptions });
-      dispatchGitCommit(sh, repoPath, template, options, overrideOptions, done);
-    });
-  }
+        console.log('Retrying last commit attempt.');
+
+        // We want to use the last commit instead of the current commit,
+        // so lets override some options using the values from cache.
+        let {
+          options: retryOptions,
+          overrideOptions: retryOverrideOptions,
+          template: retryTemplate
+        } = cache.getCacheValueSync(cachePath, repoPath);
+        dispatchGitCommit(sh, repoPath, retryTemplate, retryOptions, retryOverrideOptions, done);
+
+      } else {
+        // Get user input -- side effect that is hard to test
+        prompter(inquirer, function(error, template, overrideOptions) {
+          // Allow adapters to error out
+          // (error: Error?, template: String, overrideOptions: Object)
+          if (!(error instanceof Error)) {
+            overrideOptions = template;
+            template = error;
+            error = null;
+          }
+
+          if (error) {
+            return done(error);
+          }
+
+          // We don't want to add retries to the cache, only actual commands
+          cache.setCacheValueSync(cachePath, repoPath, { template, options, overrideOptions });
+          dispatchGitCommit(sh, repoPath, template, options, overrideOptions, done);
+        });
+      }
+    }
+  });
    
 }

--- a/test/tools/clean.js
+++ b/test/tools/clean.js
@@ -1,6 +1,5 @@
 import * as path from 'path';
-import fs from 'fs';
-import rimraf from 'rimraf';
+import fs from 'fs-extra';
 import uuid from 'node-uuid';
 
 export {
@@ -112,7 +111,7 @@ function isNormalNonZeroInteger(str) {
 function keep(sh, basePath, paths, n) {
    
   for (let i=paths.length; i>n; i--) {
-    rimraf.sync(path.resolve(basePath, paths[i-1]));
+    fs.removeSync(path.resolve(basePath, paths[i-1]));
   }
 }
 


### PR DESCRIPTION
This is a continuation of #252. I would have used the existing commits in that PR, but the branch was no longer available.

Since I added `fs-extra` for the `ensureDir` function, I also replaced `rimraf` usage with the equivalent `fs-extra` functionality.

Fixes #240, #339.
Closes #252.

## TODO

* [x] Use a release of `cachedir` that has Windows support