### PR TITLE
docs: Add cz-emoji to tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ We know that every project and build process has different requirements so we've
 - [cz-customizable](https://github.com/leonardoanalista/cz-customizable)
 - [cz-conventional-changelog-lint](https://github.com/marionebl/cz-conventional-changelog-lint)
 - [vscode-commitizen](https://github.com/KnisterPeter/vscode-commitizen)
+- [cz-emoji](https://github.com/ngryman/cz-emoji)
 
 To create an adapter, just fork one of these great adapters and modify it to suit your needs.  We pass you an instance of [Inquirer.js](https://github.com/SBoudrias/Inquirer.js/) but you can capture input using whatever means necessary. Just call the `commit` callback with a string and we'll be happy. Publish it to npm, and you'll be all set!
 


### PR DESCRIPTION
Hey,

I've made a customizable adapter using emojis to illustrate the type of commit message: https://github.com/ngryman/cz-emoji.
It's easily customizable per project using the config section of a `package.json`.

This PR adds it in the tools list of your readme. I'll be glad if you merge it and/or give me your feedback.

Thanks!