### PR TITLE
fix(package): "main" property within "package.json"

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "commitizen",
   "version": "0.0.0-semantically-released",
   "description": "Git commit, but play nice with conventions.",
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "scripts": {
     "check-coverage": "nyc check-coverage --statements 80 --branches 80 --functions 80 --lines 80 ",
     "commit": "node bin/git-cz",


### PR DESCRIPTION
_Replaces PR #408_

The current property points to src/index.js, where it really should be pointing at the dist output (i.e. dist/index.js).

I know that this is technically a CLI tool project, however, the current configuration broke a tool I was using which tries to parse the main file within each of my dependencies. As the src folder doesn't exist my tool fell over.