### PR TITLE
fix(commit): fix multiline commits with newlines

### DIFF
--- a/test/tests/commit.js
+++ b/test/tests/commit.js
@@ -213,7 +213,7 @@ describe('commit', function () {
     };
 
     let options = {
-      args: `--author="${author}" --no-edit`
+      args: [`--author="${author}"`, '--no-edit']
     };
 
     // Quick setup the repos, adapter, and grab a simple prompter

--- a/test/tests/index.js
+++ b/test/tests/index.js
@@ -3,5 +3,6 @@ import './cli';
 import './commit';
 import './configLoader';
 import './init';
+import './parsers';
 import './staging';
 import './util';

--- a/test/tests/parsers.js
+++ b/test/tests/parsers.js
@@ -1,0 +1,36 @@
+/* eslint-env mocha */
+
+import {expect} from 'chai';
+import { parse } from '../../src/cli/parsers/git-cz';
+
+describe('parsers', () => {
+  describe('git-cz', () => {
+    it('should parse --message "Hello, World!"', () => {
+      expect(parse(['--amend', '--message', 'Hello, World!'])).to.deep.equal(['--amend']);
+    });
+
+    it('should parse --message="Hello, World!"', () => {
+      expect(parse(['--amend', '--message=Hello, World!'])).to.deep.equal(['--amend']);
+    });
+
+    it('should parse -amwip', () => {
+      expect(parse(['-amwip'])).to.deep.equal(['-a']);
+    });
+
+    it('should parse -am=wip', () => {
+      expect(parse(['-am=wip'])).to.deep.equal(['-a']);
+    });
+
+    it('should parse -am wip', () => {
+      expect(parse(['-am', 'wip'])).to.deep.equal(['-a']);
+    });
+
+    it('should parse -a -m wip -n', () => {
+      expect(parse(['-a', '-m', 'wip', '-n'])).to.deep.equal(['-a', '-n']);
+    });
+
+    it('should parse -a -m=wip -n', () => {
+      expect(parse(['-a', '-m=wip', '-n'])).to.deep.equal(['-a', '-n']);
+    });
+  });
+});


### PR DESCRIPTION
This refactors `args` to always be an array, instead of converting it to a string with escaping and quoting. It uses `spawn` instead of `exec` which takes an array of arguments instead of a string.

I'm having some other strange issues with my local tests so uploading now to see how CI is...

Also, this fixes #411 