### PR TITLE
refactor(configLoader): remove deprecated czConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ This just tells Commitizen which adapter we actually want our contributors to us
 *  full relative file names
 *  absolute paths.
 
-Please note that in previous version of Commitizen we used czConfig. **czConfig has been deprecated** and you should migrate to the new format before Commitizen 3.0.0.
+Please note that in previous version of Commitizen we used czConfig. **czConfig has been removed** from Commitizen 3.0.0.
 
 #### Optional: Install and run Commitizen locally
 

--- a/src/configLoader/getNormalizedConfig.js
+++ b/src/configLoader/getNormalizedConfig.js
@@ -11,14 +11,6 @@ function getNormalizedConfig (config, content) {
     // Use the npm config key, be good citizens
     if (content.config && content.config.commitizen) {
       return content.config.commitizen;
-    } else if (content.czConfig) { // Old method, will be deprecated in 3.0.0
-    
-      // Suppress during test
-      if (typeof global.it !== 'function')
-      {
-        console.error("\n********\nWARNING: This repository's package.json is using czConfig. czConfig will be deprecated in Commitizen 3. \nPlease use this instead:\n{\n  \"config\": {\n    \"commitizen\": {\n      \"path\": \"./path/to/adapter\"\n    }\n  }\n}\nFor more information, see: http://commitizen.github.io/cz-cli/\n********\n"); 
-      }
-      return content.czConfig;
     }
   } else {
     // .cz.json or .czrc 

--- a/test/tests/configLoader.js
+++ b/test/tests/configLoader.js
@@ -30,12 +30,7 @@ describe('configLoader', function () {
       }
     };
     
-    let oldStyleConfig = {
-      czConfig: 'myOldConfig'
-    };
-    
     expect(getNormalizedConfig(config, npmStyleConfig)).to.equal('myNpmConfig');
-    expect(getNormalizedConfig(config, oldStyleConfig)).to.equal('myOldConfig');
     
   });
   


### PR DESCRIPTION
BREAKING CHANGE: czConfig is no longer read for config

@jimthedev please feel free to merge this and #416 at will :) they are both to the 3.x branch