### PR TITLE
Bump vulnerable dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "lodash": "4.17.2",
     "minimist": "1.2.0",
     "path-exists": "2.1.0",
-    "shelljs": "0.7.5",
+    "shelljs": "0.7.6",
     "strip-json-comments": "2.0.1"
   },
   "babel": {


### PR DESCRIPTION
Shelljs has been reported vulnerable: https://snyk.io/vuln/npm:shelljs
Updating to 0.7.6 as suggested by Snyk.