### PR TITLE
docs(readme): Fix incorrect spelling of "changelog"

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Commitizen is an open source project that helps contributors be good open source
 #### Commitizen or Commit Hooks
 Both! Commitizen is not meant to be a replacement for git commit hooks. Rather, it is meant to work side-by-side with them to ensure a consistent and positive experience for your contributors. Commitizen treats the commit command as a declarative action. The contributor is declaring that they wish to contribute to your project. It is up to you as the maintainer to define what rules they should be following.
 
-We accomplish this by letting you define which adapter you'd like to use in your project. Adapters just allow multiple projects to share the same commit message conventions. A good example of an adapter is the cz-conventional-changlog adapter.
+We accomplish this by letting you define which adapter you'd like to use in your project. Adapters just allow multiple projects to share the same commit message conventions. A good example of an adapter is the cz-conventional-changelog adapter.
 
 ### Authors and Contributors
 @JimTheDev (Jim Cummins, author)


### PR DESCRIPTION
`cz-conventional-changlog` is missing an "e."

Closes #426