### PR TITLE
fix(adapter): Don't print git root to stdout

### DIFF
--- a/src/commitizen/adapter.js
+++ b/src/commitizen/adapter.js
@@ -150,5 +150,5 @@ function resolveAdapterPath (inboundAdapterPath) {
 }
 
 function getGitRootPath () {
-  return sh.exec('git rev-parse --show-toplevel').stdout.trim();
+  return sh.exec('git rev-parse --show-toplevel', {silent: true}).stdout.trim();
 }


### PR DESCRIPTION
Whenever this is ran, it also prints out to the console. This should just be silenced since it's just being used internally.