### PR TITLE
fix(cli): Don't print error stack trace if git-cz failed (#436)

### DIFF
--- a/bin/git-cz.js
+++ b/bin/git-cz.js
@@ -1,4 +1,10 @@
 var path = require('path');
+
+process.on('uncaughtException', function (err) {
+  console.error(err.message || err);
+  process.exit(1);
+})
+
 require('../dist/cli/git-cz.js').bootstrap({
   cliPath: path.join(__dirname, '../')
 });


### PR DESCRIPTION
Fixes #436 