### PR TITLE
docs: Fix Angular commit conventions link

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ As a project maintainer, making your repo Commitizen friendly allows you to sele
 
 #### Making your repo Commitizen-friendly
 
-For this example, we'll be setting up our repo to use [AngularJS's commit message convention](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#-git-commit-guidelines) also known as [conventional-changelog](https://github.com/ajoslin/conventional-changelog).
+For this example, we'll be setting up our repo to use [AngularJS's commit message convention](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) also known as [conventional-changelog](https://github.com/ajoslin/conventional-changelog).
 
 First, install the Commitizen cli tools:
 


### PR DESCRIPTION
Changed 3 days ago: https://github.com/angular/angular.js/commit/181ac0b7a1823bd9965f5e88b3c5b437dc00fafd