### PR TITLE
fix(cli): Respect git commit -a original behavior (#376)

### DIFF
--- a/src/cli/strategies/git-cz.js
+++ b/src/cli/strategies/git-cz.js
@@ -25,11 +25,6 @@ function gitCz (rawGitArgs, environment, adapterConfig) {
   // commit strategy than git-cz. For example, in the case of --amend
   let parsedCommitizenArgs = commitizenParser.parse(rawGitArgs);
   
-  if (parsedCommitizenArgs.a) {
-    // console.log('override -a in place');
-    addPath(sh, process.cwd());
-  }
-  
   if (parsedCommitizenArgs.amend) {
     // console.log('override --amend in place');
     gitStrategy.default(rawGitArgs, environment);

--- a/src/git.js
+++ b/src/git.js
@@ -1,11 +1,14 @@
-import {addPath} from './git/add';
+import {addPath, addFile} from './git/add';
 import {commit} from './git/commit';
 import {init} from './git/init';
 import {log} from './git/log';
+import {whatChanged} from './git/whatChanged';
 
 export {
   addPath,
+  addFile,
   commit,
   init,
-  log
+  log,
+  whatChanged
 };

--- a/src/git/add.js
+++ b/src/git/add.js
@@ -1,4 +1,7 @@
-export { addPath };
+export {
+  addPath,
+  addFile
+}
 
 /**
  * Synchronously adds a path to git staging
@@ -6,4 +9,12 @@ export { addPath };
 function addPath (sh, repoPath) {
   sh.cd(repoPath);
   sh.exec('git add .');
+}
+
+/**
+ * Synchronously adds a file to git staging
+ */
+function addFile (sh, repoPath, filename) {
+  sh.cd(repoPath);
+  sh.exec('git add ' + filename)
 }

--- a/src/git/whatChanged.js
+++ b/src/git/whatChanged.js
@@ -1,0 +1,18 @@
+import { exec } from 'child_process';
+
+export { whatChanged };
+
+/**
+ * Asynchronously gets the git whatchanged output
+ */
+function whatChanged (repoPath, done) {
+  exec('git whatchanged', {
+    maxBuffer: Infinity,
+    cwd: repoPath
+  }, function (error, stdout, stderr) {
+    if (error) {
+      throw error;
+    }
+    done(stdout);
+  });
+}


### PR DESCRIPTION
We don't overload the `-a` option anymore with a plain `git add .`.

I have a second commit that adds tests for this fix, but unfortunately it required quite some changes and additions...