### PR TITLE
feat(strategies): respect the `--allow-emtpy` flag

### DIFF
--- a/src/cli/strategies/git-cz.js
+++ b/src/cli/strategies/git-cz.js
@@ -52,7 +52,7 @@ function gitCz (rawGitArgs, environment, adapterConfig) {
       throw error;
     }
 
-    if (stagingIsClean) {
+    if (stagingIsClean && !parsedGitCzArgs.includes('--allow-empty')) {
       throw new Error('No files added to staging! Did you forget to run git add?');
     }
 


### PR DESCRIPTION
This adds the feature to respect the git `allow-empty` flag and enable git cz to create empty
commits.

Closes #476