### PR TITLE
fix(config): prioritized package.json last when looking for config files

### DIFF
--- a/src/commitizen/configLoader.js
+++ b/src/commitizen/configLoader.js
@@ -3,7 +3,7 @@ import {loader} from '../configLoader';
 export { load };
 
 // Configuration sources in priority order.
-var configs = ['package.json', '.czrc', '.cz.json'];
+var configs = ['.czrc', '.cz.json', 'package.json'];
 
 function load (config, cwd) {
   return loader(configs, config, cwd);


### PR DESCRIPTION
since package.json was prioritized first, it is always found and always used, even if it does not contain commitizen config. the other optional config files are never found as a result. this change looks for the optional files first and only lands on the package.json if the other files do not exist

fixes #478