### PR TITLE
BREAKING CHANGE: Remove Node 0.12 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,12 @@ branches:
 notifications:
   email: false
 node_js:
+- '9'
+- '8'
 - '7'
 - '6'
 - '5'
 - '4'
-- '0.12'
 before_install:
 - git config --global user.name "TravisCI"
 - git config --global user.email "commitizen@gmail.com"


### PR DESCRIPTION
Remove Node 0.12 support due to mocha (our tests) dropping support.
Add Node 8, 9 support.