### PR TITLE
docs: fix font in code blocks

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -167,7 +167,7 @@ a.button span {
 
 code, pre {
   margin-bottom: 30px;
-  font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal;
+  font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
   font-size: 14px;
   color: #222;
 }


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/9433472/45703506-6af36c00-bb6c-11e8-90a1-4c2f12aed705.png)

After:

![image](https://user-images.githubusercontent.com/9433472/45703509-721a7a00-bb6c-11e8-8f94-f4c182f35aac.png)

Fixes #565.