### PR TITLE
fix(cli): allow argv to be overridden in bootstrap

### DIFF
--- a/src/cli/commitizen.js
+++ b/src/cli/commitizen.js
@@ -12,10 +12,10 @@ export {
  * This is the main cli entry point.
  * environment may be used for debugging.
  */
-function bootstrap (environment = {}) {
+function bootstrap (environment = {}, argv = process.argv) {
 
   // Get cli args
-  let rawGitArgs = process.argv.slice(2, process.argv.length);
+  let rawGitArgs = argv.slice(2, argv.length);
 
   // Parse the args
   let parsedArgs = parse(rawGitArgs);

--- a/src/cli/git-cz.js
+++ b/src/cli/git-cz.js
@@ -9,10 +9,10 @@ export {
  * This is the main cli entry point.
  * environment may be used for debugging.
  */
-function bootstrap (environment = {}) {
+function bootstrap (environment = {}, argv = process.argv) {
 
   // Get cli args
-  let rawGitArgs = process.argv.slice(2, process.argv.length);
+  let rawGitArgs = argv.slice(2, argv.length);
 
   let adapterConfig = environment.config || configLoader.load();
 

--- a/test/tests/cli.js
+++ b/test/tests/cli.js
@@ -57,5 +57,12 @@ describe('git-cz', () => {
         });
       });
     });
+
+    describe('when argv is overridden', () => {
+      it('uses the overridden argv', () => {
+        bootstrap({}, ['node', 'git-cz', 'index.js']);
+        expect(fakeStrategies.git.args[0][0][0]).to.equal('index.js');
+      });
+    })
   });
 });


### PR DESCRIPTION
*why*: in case a consumer's CLI has extra arguments, allowing argv to be overridden without mutating the process.argv array directly would be useful.

In our application, we're manually maniuplating process.argv using methods like `Array.prototype.splice` to get around this, but we would definitely prefer to do this immutably instead and pass our final argv to you this way.