### PR TITLE
docs: fix typo in code inside README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ bootstrap({
 
 {
   "name": "company-commit",
-  "bin": "./my-cli.js"
+  "bin": "./my-cli.js",
   "dependencies": {
     "commitizen": "^2.7.6",
     "cz-conventional-changelog": "^1.1.5",


### PR DESCRIPTION
Missing comma in code snippet inside 'Commitizen for multi-repo projects' section