### PR TITLE
fix(cli): Exit CLI with 1(as failed) when received SIGINT

### DIFF
--- a/bin/git-cz.js
+++ b/bin/git-cz.js
@@ -8,7 +8,7 @@ process.on('uncaughtException', function (err) {
 // catch SIGINT signal
 process.stdin.on('data', function (key) {
   if (key == '\u0003') {
-    process.exit(1);
+    process.exit(130); // 128 + SIGINT
   }
 });
 

--- a/bin/git-cz.js
+++ b/bin/git-cz.js
@@ -3,7 +3,14 @@ var path = require('path');
 process.on('uncaughtException', function (err) {
   console.error(err.message || err);
   process.exit(1);
-})
+});
+
+// catch SIGINT signal
+process.stdin.on('data', function (key) {
+  if (key == '\u0003') {
+    process.exit(1);
+  }
+});
 
 require('../dist/cli/git-cz.js').bootstrap({
   cliPath: path.join(__dirname, '../')


### PR DESCRIPTION
fix #688 

commitizen always exit with 0(as succeeded) even if user inputs `CTRL-C`, it caused by `Inquirer.js` traps SIGINT.

In this PR, Fix issue by applying workaround which suggested in [issue](https://github.com/SBoudrias/Inquirer.js/issues/405) of `Inquirer.js`.

commitizen now exit with 1(as failed) when `CTRL-C` inputted.