### PR TITLE
docs: add adapter for jira

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ npm install company-commit --save-dev
 We know that every project and build process has different requirements so we've tried to keep Commitizen open for extension. You can do this by choosing from any of the pre-build adapters or even by building your own. Here are some of the great adapters available to you:
 
 - [cz-conventional-changelog](https://www.npmjs.com/package/cz-conventional-changelog)
+- [cz-conventional-changelog-for-jira](https://www.npmjs.com/package/@digitalroute/cz-conventional-changelog-for-jira)
 - [cz-jira-smart-commit](https://www.npmjs.com/package/cz-jira-smart-commit)
 - [@endemolshinegroup/cz-jira-smart-commit](https://github.com/EndemolShineGroup/cz-jira-smart-commit)
 - [@endemolshinegroup/cz-github](https://github.com/EndemolShineGroup/cz-github)


### PR DESCRIPTION
We have created an adapter that is purposed for the JIRA workflow when you don't use _smart commits_. We have made sure that the adapter is well documented and easy to use.

We think that it is unique and would love for it to be recognized.