### PR TITLE
docs: Update `commitlint` adapter link

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ We know that every project and build process has different requirements so we've
 - [rb-conventional-changelog](https://www.npmjs.com/package/rb-conventional-changelog)
 - [cz-mapbox-changelog](https://www.npmjs.com/package/cz-mapbox-changelog)
 - [cz-customizable](https://github.com/leonardoanalista/cz-customizable)
-- [commitlint](https://github.com/marionebl/commitlint)
+- [commitlint](https://github.com/conventional-changelog/commitlint/tree/master/@commitlint/prompt#commitlintprompt)
 - [vscode-commitizen](https://github.com/KnisterPeter/vscode-commitizen)
 - [cz-emoji](https://github.com/ngryman/cz-emoji)
 - [cz-adapter-eslint](https://www.npmjs.com/package/cz-adapter-eslint)


### PR DESCRIPTION
The current link that is supposed to go to the "commitlint adapter" essentially redirects to the commitlint doc site. The commitlint doc site really only talks about using the `prompt-cli` as a standalone utility, and doesn't have any explicit documentation on using the prompt _adapter_ (which is a separate package) with commitizen. And, the commitlint site just links _back_ to the commitizen doc site, so I was lucky to even stumble upon a buried readme, honestly.