### PR TITLE
feat: use cz as binary name

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ npm install -g commitizen
 
 ### If your repo is [Commitizen-friendly]:
 
-Simply use `git cz` instead of `git commit` when committing.
+Simply use `git cz` or just `cz` instead of `git commit` when committing. You can also use `git-cz`, which is an alias for `cz`.
 
 _Alternatively_, if you are using **NPM 5.2+** you can [use `npx`](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b) instead of installing globally:
 
 ```
-npx git-cz
+npx cz
 ```
 
 or as an npm script:
@@ -35,7 +35,7 @@ or as an npm script:
 ```json
   ...
   "scripts": {
-    "commit": "npx git-cz"
+    "commit": "cz"
   }
 ```
 
@@ -45,7 +45,7 @@ When you're working in a Commitizen friendly repository, you'll be prompted to f
 
 ### If your repo is NOT Commitizen friendly:
 
-If you're **not** working in a Commitizen friendly repository, then `git cz` will work just the same as `git commit` but `npx git-cz` will use the [streamich/git-cz](https://github.com/streamich/git-cz) adapter. To fix this, you need to first [make your repo Commitizen-friendly](#making-your-repo-commitizen-friendly)
+If you're **not** working in a Commitizen friendly repository, then `git cz` will work just the same as `git commit` but `npx cz` will use the [streamich/git-cz](https://github.com/streamich/git-cz) adapter. To fix this, you need to first [make your repo Commitizen-friendly](#making-your-repo-commitizen-friendly)
 
 ## Making your repo Commitizen-friendly
 
@@ -118,7 +118,7 @@ On **NPM 5.2+** you can [use `npx`](https://medium.com/@maybekatz/introducing-np
 npx commitizen init cz-conventional-changelog --save-dev --save-exact
 ```
 
-For **previous versions of NPM (< 5.2)** you can execute `./node_modules/.bin/commitizen` or `./node_modules/.bin/git-cz` in order to actually use the commands.
+For **previous versions of NPM (< 5.2)** you can execute `./node_modules/.bin/commitizen` or `./node_modules/.bin/cz` in order to actually use the commands.
 
 You can then initialize the conventional changelog adapter using: `./node_modules/.bin/commitizen init cz-conventional-changelog --save-dev --save-exact`
 
@@ -127,13 +127,15 @@ And you can then add some nice npm run scripts in your package.json pointing to 
 ```json
   ...
   "scripts": {
-    "commit": "git-cz"
+    "commit": "cz"
   }
 ```
 
 This will be more convenient for your users because then if they want to do a commit, all they need to do is run `npm run commit` and they will get the prompts needed to start a commit!
 
-> **NOTE:** if you are using `precommit` hooks thanks to something like `husky`, you will need to name your script some thing other than "commit" (e.g. "cm": "git-cz"). The reason is because npm-scripts has a "feature" where it automatically runs scripts with the name _prexxx_ where _xxx_ is the name of another script. In essence, npm and husky will run "precommit" scripts twice if you name the script "commit," and the work around is to prevent the npm-triggered _precommit_ script.
+> **NOTE:** if you are using `precommit` hooks thanks to something like [`husky`](https://www.npmjs.com/package/husky), you will need to name your script some thing other than `"commit"`
+> (e.g. `"cm": "cz"`). The reason is because npm-scripts has a "feature" where it automatically runs scripts with the name _prexxx_ where _xxx_ is the name of another script. In essence,
+> npm and husky will run `"precommit"` scripts twice if you name the script `"commit"`, and the work around is to prevent the npm-triggered _precommit_ script.
 
 #### Optional: Running Commitizen on `git commit`
 
@@ -150,7 +152,7 @@ Update `.git/hooks/prepare-commit-msg` with the following code:
 
 ```
 #!/bin/bash
-exec < /dev/tty && node_modules/.bin/git-cz --hook || true
+exec < /dev/tty && node_modules/.bin/cz --hook || true
 ```
 
 ##### Husky
@@ -282,11 +284,10 @@ As of version 2.7.1, you may attempt to retry the last commit using the `git cz 
 
 Please note that the retry cache may be cleared when upgrading commitizen versions, upgrading adapters, or if you delete the `commitizen.json` file in your home or temp directory. Additionally, the commit cache uses the filesystem path of the repo, so if you move a repo or change its path, you will not be able to retry a commit. This is an edge case, but might be confusing if you have scenarios where you are moving folders that contain repos.
 
-It is important to note that if you are running `git-cz` from a npm script (let's say it is called `commit`) you will need to do one of the following:
+It is important to note that if you are running `cz` from a npm script (let's say it is called `commit`) you will need to do one of the following:
 
 - Pass `-- --retry` as an argument for your script. i.e: `npm run commit -- --retry`
-- Use [npm-run](https://www.npmjs.com/package/npm-run) to find and call git-cz executable directly. i.e: `npm-run git-cz --retry`
-- Use [npm-quick-run](https://www.npmjs.com/package/npm-quick-run) i.e: `nr commit --retry` or just `nr c --retry` (which will run all scripts that starts with the letter 'c')
+- Use [npx](https://www.npmjs.com/package/npx) to find and call `cz` executable directly. i.e: `npx cz --retry`
 
 Note that the last two options **do not** require you to pass `--` before the args but the first **does**.
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "url": "https://github.com/commitizen/cz-cli/issues"
   },
   "bin": {
+    "cz": "./bin/git-cz",
     "git-cz": "./bin/git-cz",
     "commitizen": "./bin/commitizen"
   },

--- a/src/cli/commitizen.js
+++ b/src/cli/commitizen.js
@@ -38,14 +38,15 @@ function bootstrap (environment = {}, argv = process.argv) {
 
     Commitizen has two command line tools:
 
-      1) commitizen -- used for installing adapters into your project
-      2) git-cz     -- used for making commits according to convention
+      1) cz         -- used for making commits according to convention
                        note: you can run 'git cz' if installed with -g
+      2) git-cz     -- alias for 'cz'
+      3) commitizen -- used for installing adapters into your project
 
     Generally if you're using someone else's repo and they've already set up an
     adapter, you're going to just be running:
 
-         git-cz
+         cz
 
     However, if you create a new repo and you want to make it easier for future
     contributors to follow your commit message conventions using commitizen then
@@ -71,13 +72,13 @@ function bootstrap (environment = {}, argv = process.argv) {
              --save-exact   Install an exact version instead of a range
              --force        Force install the adapter, even if a previous one exists.
 
-      2) git-cz <any regular git commit arguments>
+      2) cz <any regular git commit arguments>
 
           description: Runs the commitizen prompter, asking you questions so that you
                        follow the commit conventions of the repository of the current
                        directory.
 
-                       note: git-cz may even be run as 'git cz' if installed with -g.
+                       note: cz may even be run as 'git cz' if installed with -g.
 
     `);
   }

--- a/src/cli/strategies/git.js
+++ b/src/cli/strategies/git.js
@@ -6,7 +6,7 @@ export default git;
 // or if debug is enabled then we do a strict check for a config file.
 function git (rawGitArgs, environment) {
   if (environment.debug === true) {
-    console.error('COMMITIZEN DEBUG: No git-cz friendly config was detected. I looked for .czrc, .cz.json, or czConfig in package.json.');
+    console.error('COMMITIZEN DEBUG: No cz friendly config was detected. I looked for .czrc, .cz.json, or czConfig in package.json.');
   } else {
     var vanillaGitArgs = ["commit"].concat(rawGitArgs);
 


### PR DESCRIPTION
While still support the old git-cz binary name. Also improve the
documentation.

Closes #761