### PR TITLE
docs(readme.md): add a new reference to adapter section

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ We know that every project and build process has different requirements so we've
 
 - [cz-conventional-changelog](https://www.npmjs.com/package/cz-conventional-changelog)
 - [cz-conventional-changelog-for-jira](https://www.npmjs.com/package/@digitalroute/cz-conventional-changelog-for-jira)
+- [cz-conventional-changelog-with-jiraid-detection](https://www.npmjs.com/package/cz-conventional-changelog-with-jiraid-detection)
 - [cz-jira-smart-commit](https://www.npmjs.com/package/cz-jira-smart-commit)
 - [@endemolshinegroup/cz-jira-smart-commit](https://github.com/EndemolShineGroup/cz-jira-smart-commit)
 - [@endemolshinegroup/cz-github](https://github.com/EndemolShineGroup/cz-github)


### PR DESCRIPTION
**Changes**
- Add a new adapter [`cz-conventional-changelog-with-jiraid-detection`](https://www.npmjs.com/package/cz-conventional-changelog-with-jiraid-detection) to the Adapters section. It is a handy adapter for teams that work with JIRA. The adapter automatically detects JIRA ID from the current branch name and offers an additional prompt step to ask for JIRA ID input with detected JIRA ID as default.