### PR TITLE
fix: revert "use cz-conventional-changelog as default adapter (#778)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ When you're working in a Commitizen friendly repository, you'll be prompted to f
 
 [![Add and commit with Commitizen](https://github.com/commitizen/cz-cli/raw/master/meta/screenshots/add-commit.png)](https://github.com/commitizen/cz-cli/raw/master/meta/screenshots/add-commit.png)
 
-### If your repo is NOT Commitizen-friendly
+### If your repo is NOT Commitizen friendly:
 
-If you're **not** working in a Commitizen friendly repository, then `git cz` will work just the same as `git commit` but `npx cz` will use the [cz-conventional-changelog](https://github.com/commitizen/cz-conventional-changelog) adapter. To fix this, you need to first [make your repo Commitizen-friendly](#making-your-repo-commitizen-friendly).
+If you're **not** working in a Commitizen friendly repository, then `git cz` will work just the same as `git commit` but `npx cz` will use the [streamich/git-cz](https://github.com/streamich/git-cz) adapter. To fix this, you need to first [make your repo Commitizen-friendly](#making-your-repo-commitizen-friendly)
 
 ## Making your repo Commitizen-friendly
 
-For this example, we'll be setting up our repo to use [Conventional Commits convention](https://www.conventionalcommits.org/) through the [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) [commitizen adapter](https://github.com/commitizen/cz-conventional-changelog).
+For this example, we'll be setting up our repo to use [AngularJS's commit message convention](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) also known as [conventional-changelog](https://github.com/ajoslin/conventional-changelog).
 
 First, install the Commitizen cli tools:
 
@@ -86,7 +86,7 @@ The above command does three things for you.
   }
 ```
 
-Alternatively, commitizen configs may be added to a `.czrc` or `.cz.json` file:
+Alternatively, commitizen configs may be added to a .czrc file:
 
 ```json
 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1808,27 +1808,39 @@
         }
       }
     },
-    "@commitlint/execute-rule": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-11.0.0.tgz",
-      "integrity": "sha512-g01p1g4BmYlZ2+tdotCavrMunnPFPhTzG1ZiLKTCYrooHRbmvqo42ZZn4QMStUEIcn+jfLb6BRZX3JzIwA1ezQ==",
-      "optional": true
-    },
     "@commitlint/load": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-11.0.0.tgz",
-      "integrity": "sha512-t5ZBrtgvgCwPfxmG811FCp39/o3SJ7L+SNsxFL92OR4WQxPcu6c8taD0CG2lzOHGuRyuMxZ7ps3EbngT2WpiCg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-10.0.0.tgz",
+      "integrity": "sha512-pUwGshEpxkU2R9U3O5hwHU4VT0zkyIs5gzGrGbR2c/aurI9qe00LZ9DquYVVYVmfwG6UaQpatCG4TrXNXIj5Mg==",
       "optional": true,
       "requires": {
-        "@commitlint/execute-rule": "^11.0.0",
-        "@commitlint/resolve-extends": "^11.0.0",
-        "@commitlint/types": "^11.0.0",
+        "@commitlint/execute-rule": "^10.0.0",
+        "@commitlint/resolve-extends": "^10.0.0",
+        "@commitlint/types": "^10.0.0",
         "chalk": "4.1.0",
         "cosmiconfig": "^7.0.0",
         "lodash": "^4.17.19",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
+        "@commitlint/execute-rule": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-10.0.0.tgz",
+          "integrity": "sha512-vRIp6Cwy+C1dOh5VAcoBks+8UI+rpxOB5cwhU/RQZhlVd2hgFiAPXnyKWMOB7HDO9XFI5amLJehvaaDI+eLDnA==",
+          "optional": true
+        },
+        "@commitlint/resolve-extends": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-10.0.0.tgz",
+          "integrity": "sha512-ltj4LvdCEJeYzWdzFS9AhLMkc4rweKvfju/JYBgbLqFx7lAGz3e2Wub0uuuWuLBJqCjL7UJbYiA0T2Hzhhd91Q==",
+          "optional": true,
+          "requires": {
+            "import-fresh": "^3.0.0",
+            "lodash": "^4.17.19",
+            "resolve-from": "^5.0.0",
+            "resolve-global": "^1.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
@@ -1902,14 +1914,14 @@
           }
         },
         "parse-json": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
-          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
+          "integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
           "optional": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
-            "json-parse-even-better-errors": "^2.3.0",
+            "json-parse-better-errors": "^1.0.1",
             "lines-and-columns": "^1.1.6"
           }
         },
@@ -1920,9 +1932,9 @@
           "optional": true
         },
         "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "optional": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -1930,42 +1942,10 @@
         }
       }
     },
-    "@commitlint/resolve-extends": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-11.0.0.tgz",
-      "integrity": "sha512-WinU6Uv6L7HDGLqn/To13KM1CWvZ09VHZqryqxXa1OY+EvJkfU734CwnOEeNlSCK7FVLrB4kmodLJtL1dkEpXw==",
-      "optional": true,
-      "requires": {
-        "import-fresh": "^3.0.0",
-        "lodash": "^4.17.19",
-        "resolve-from": "^5.0.0",
-        "resolve-global": "^1.0.0"
-      },
-      "dependencies": {
-        "import-fresh": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
-          "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
-          "optional": true,
-          "requires": {
-            "parent-module": "^1.0.0",
-            "resolve-from": "^4.0.0"
-          },
-          "dependencies": {
-            "resolve-from": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-              "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-              "optional": true
-            }
-          }
-        }
-      }
-    },
     "@commitlint/types": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-11.0.0.tgz",
-      "integrity": "sha512-VoNqai1vR5anRF5Tuh/+SWDFk7xi7oMwHrHrbm1BprYXjB2RJsWLhUrStMssDxEl5lW/z3EUdg8RvH/IUBccSQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-10.0.0.tgz",
+      "integrity": "sha512-b7uumSfDI1guYnNc11BpkTZjiY7gC1DPedeUa0r+csd/1DiFyRo4oNOaxXHve0cC4NzaHaOHa0aPktWMTYJlVQ==",
       "optional": true
     },
     "@istanbuljs/load-nyc-config": {
@@ -3523,8 +3503,7 @@
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "optional": true
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "camelcase": {
       "version": "5.3.1",
@@ -3788,9 +3767,9 @@
       "dev": true
     },
     "commitizen": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/commitizen/-/commitizen-4.2.1.tgz",
-      "integrity": "sha512-nZsp8IThkDu7C+93BFD/mLShb9Gd6Wsaf90tpKE3x/6u5y/Q52kzanIJpGr0qvIsJ5bCMpgKtr3Lbu3miEJfaA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/commitizen/-/commitizen-4.1.2.tgz",
+      "integrity": "sha512-LBxTQKHbVgroMz9ohpm86N+GfJobonGyvDc3zBGdZazbwCLz2tqLa48Rf2TnAdKx7/06W1i1R3SXUt5QW97qVQ==",
       "requires": {
         "cachedir": "2.2.0",
         "cz-conventional-changelog": "3.2.0",
@@ -3800,37 +3779,51 @@
         "find-root": "1.1.0",
         "fs-extra": "8.1.0",
         "glob": "7.1.4",
-        "inquirer": "6.5.2",
+        "inquirer": "6.5.0",
         "is-utf8": "^0.2.1",
-        "lodash": "^4.17.20",
+        "lodash": "4.17.15",
         "minimist": "1.2.5",
         "strip-bom": "4.0.0",
         "strip-json-comments": "3.0.1"
       },
       "dependencies": {
-        "conventional-commit-types": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-3.0.0.tgz",
-          "integrity": "sha512-SmmCYnOniSsAa9GqWOeLqc179lfr5TRu5b4QFDkbsrJ5TZjPJx85wtOr3zn+1dbeNiXDKGPbZ72IKbPhLXh/Lg=="
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
-        "cz-conventional-changelog": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.2.0.tgz",
-          "integrity": "sha512-yAYxeGpVi27hqIilG1nh4A9Bnx4J3Ov+eXy4koL3drrR+IO9GaWPsKjik20ht608Asqi8TQPf0mczhEeyAtMzg==",
+        "inquirer": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
+          "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
           "requires": {
-            "@commitlint/load": ">6.1.1",
-            "chalk": "^2.4.1",
-            "commitizen": "^4.0.3",
-            "conventional-commit-types": "^3.0.0",
-            "lodash.map": "^4.5.1",
-            "longest": "^2.0.1",
-            "word-wrap": "^1.0.3"
+            "ansi-escapes": "^3.2.0",
+            "chalk": "^2.4.2",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^3.0.3",
+            "figures": "^2.0.0",
+            "lodash": "^4.17.12",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rxjs": "^6.4.0",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^5.1.0",
+            "through": "^2.3.6"
           }
         },
-        "longest": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/longest/-/longest-2.0.1.tgz",
-          "integrity": "sha1-eB4YMpaqlPbU2RbcM10NF676I/g="
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
         }
       }
     },
@@ -4098,9 +4091,9 @@
       "optional": true
     },
     "cz-conventional-changelog": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.3.0.tgz",
-      "integrity": "sha512-U466fIzU5U22eES5lTNiNbZ+d8dfcHcssH4o7QsdWaCcRs/feIPCxKYSWkYBNs5mny7MvEfwpTLWjvbm94hecw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.2.0.tgz",
+      "integrity": "sha512-yAYxeGpVi27hqIilG1nh4A9Bnx4J3Ov+eXy4koL3drrR+IO9GaWPsKjik20ht608Asqi8TQPf0mczhEeyAtMzg==",
       "requires": {
         "@commitlint/load": ">6.1.1",
         "chalk": "^2.4.1",
@@ -6278,14 +6271,7 @@
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-      "dev": true
-    },
-    "json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "optional": true
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "cachedir": "2.2.0",
-    "cz-conventional-changelog": "3.3.0",
+    "cz-conventional-changelog": "3.2.0",
     "dedent": "0.7.0",
     "detect-indent": "6.0.0",
     "find-node-modules": "2.0.0",

--- a/src/cli/git-cz.js
+++ b/src/cli/git-cz.js
@@ -1,5 +1,5 @@
 import { configLoader } from '../commitizen';
-import { gitCz as useGitCzStrategy } from './strategies';
+import { git as useGitStrategy, gitCz as useGitCzStrategy } from './strategies';
 
 export {
   bootstrap
@@ -9,12 +9,19 @@ export {
  * This is the main cli entry point.
  * environment may be used for debugging.
  */
-function bootstrap(environment = {}, argv = process.argv) {
+function bootstrap (environment = {}, argv = process.argv) {
 
   // Get cli args
   let rawGitArgs = argv.slice(2, argv.length);
 
-  let adapterConfig = environment.config || configLoader.load() || { path: 'cz-conventional-changelog' };
+  let adapterConfig = environment.config || configLoader.load();
 
-  useGitCzStrategy(rawGitArgs, environment, adapterConfig);
+  // Choose a strategy based on the existance the adapter config
+  if (typeof adapterConfig !== 'undefined') {
+    // This tells commitizen we're in business
+    useGitCzStrategy(rawGitArgs, environment, adapterConfig);
+  } else {
+    // This tells commitizen that it is not needed, just use git
+    useGitStrategy(rawGitArgs, environment);
+  }
 }

--- a/test/tests/cli.js
+++ b/test/tests/cli.js
@@ -8,6 +8,7 @@ describe('git-cz', () => {
 
   beforeEach(() => {
     fakeStrategies = {
+      git: sinon.spy(),
       gitCz: sinon.spy()
     }
 
@@ -48,10 +49,9 @@ describe('git-cz', () => {
       });
 
       describe('and the config is not returned from configLoader.load', () => {
-        it('tells commitizen to use the default adapter', () => {
+        it('tells commitizen to use the git strategy', () => {
           bootstrap({});
-
-          expect(fakeStrategies.gitCz.args[0][2].path).to.equal('cz-conventional-changelog');
+          expect(fakeStrategies.git.called).to.equal(true);
         });
       });
     });
@@ -59,7 +59,7 @@ describe('git-cz', () => {
     describe('when argv is overridden', () => {
       it('uses the overridden argv', () => {
         bootstrap({}, ['node', 'git-cz', 'index.js']);
-        expect(fakeStrategies.gitCz.args[0][0][0]).to.equal('index.js');
+        expect(fakeStrategies.git.args[0][0][0]).to.equal('index.js');
       });
     })
   });


### PR DESCRIPTION
This reverts commit e6b75cb8d00f18d474e8eadf4bb87ac4e6291b00.

It was supposed to be released as a breaking change.

Refs: https://github.com/commitizen/cz-cli/pull/778#issuecomment-713177887