### PR TITLE
docs: correct package name of cz-mapbox-changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ We know that every project and build process has different requirements so we've
 - [@endemolshinegroup/cz-jira-smart-commit](https://github.com/EndemolShineGroup/cz-jira-smart-commit)
 - [@endemolshinegroup/cz-github](https://github.com/EndemolShineGroup/cz-github)
 - [rb-conventional-changelog](https://www.npmjs.com/package/rb-conventional-changelog)
-- [cz-mapbox-changelog](https://www.npmjs.com/package/cz-mapbox-changelog)
+- [@mapbox/cz-mapbox-changelog](https://www.npmjs.com/package/@mapbox/cz-mapbox-changelog)
 - [cz-customizable](https://github.com/leonardoanalista/cz-customizable)
 - [commitlint](https://github.com/conventional-changelog/commitlint/tree/master/@commitlint/prompt)
 - [vscode-commitizen](https://github.com/KnisterPeter/vscode-commitizen)


### PR DESCRIPTION
[`cz-mapbox-changelog`](https://www.npmjs.com/package/cz-mapbox-changelog) is moved to [`@mapbox/cz-mapbox-changelog`](https://www.npmjs.com/package/@mapbox/cz-mapbox-changelog).