### PR TITLE
chore(deps): update dependency find-node-moduels to v2.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3792,6 +3792,15 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
+        "find-node-modules": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-2.0.0.tgz",
+          "integrity": "sha512-8MWIBRgJi/WpjjfVXumjPKCtmQ10B+fjx6zmSA+770GMJirLhWIzg8l763rhjl9xaeaHbnxPNRQKq2mgMhr+aw==",
+          "requires": {
+            "findup-sync": "^3.0.0",
+            "merge": "^1.2.1"
+          }
+        },
         "inquirer": {
           "version": "6.5.0",
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
@@ -4879,12 +4888,68 @@
       }
     },
     "find-node-modules": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-2.0.0.tgz",
-      "integrity": "sha512-8MWIBRgJi/WpjjfVXumjPKCtmQ10B+fjx6zmSA+770GMJirLhWIzg8l763rhjl9xaeaHbnxPNRQKq2mgMhr+aw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-2.1.1.tgz",
+      "integrity": "sha512-46adfFV0T5wQ00Ju+3E8LE/th+pY9PUzzC7taZfru6cYe7rjxXLo7QHv8OdN7dn/2MN12LKaRo/WcmXIVzdBtw==",
       "requires": {
-        "findup-sync": "^3.0.0",
-        "merge": "^1.2.1"
+        "findup-sync": "^4.0.0",
+        "merge": "^2.1.0"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "findup-sync": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
+          "integrity": "sha512-6jvvn/12IC4quLBL1KNokxC7wWTvYncaVUYSoxWw7YykPLuRrnv4qdHcSOywOI5RpkOVGeQRtWM8/q+G6W6qfQ==",
+          "requires": {
+            "detect-file": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "micromatch": "^4.0.2",
+            "resolve-dir": "^1.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+        },
+        "merge": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/merge/-/merge-2.1.0.tgz",
+          "integrity": "sha512-TcuhVDV+e6X457MQAm7xIb19rWhZuEDEho7RrwxMpQ/3GhD5sDlnP188gjQQuweXHy9igdke5oUtVOXX1X8Sxg=="
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
       }
     },
     "find-root": {
@@ -12412,8 +12477,7 @@
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
     },
     "pify": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "cz-conventional-changelog": "3.2.0",
     "dedent": "0.7.0",
     "detect-indent": "6.0.0",
-    "find-node-modules": "2.0.0",
+    "find-node-modules": "2.1.1",
     "find-root": "1.1.0",
     "fs-extra": "8.1.0",
     "glob": "7.1.4",


### PR DESCRIPTION
A security vulnerability was fixed in the find-node-moduels@2.1.1. See: https://github.com/callumacrae/find-node-modules/pull/13

