### PR TITLE
Fix husky prepare-commit-msg script for running Commitizen on `git commit` when installed locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ For `husky` users, add the following configuration to the project's `package.jso
 ```json
 "husky": {
   "hooks": {
-    "prepare-commit-msg": "exec < /dev/tty && git cz --hook || true",
+    "prepare-commit-msg": "exec < /dev/tty && node_modules/.bin/cz --hook || true",
   }
 }
 ```


### PR DESCRIPTION
The snippet to setup husky to run cz when `git commit` is run assumes the developer has setup the command `git cz` globally and throws an error: `git: 'cz' is not a git command. See 'git --help'.`

The fix references the locally installed cz as the git hook example above it.