### PR TITLE
[Fix] Check for staged files prior to spawning the prompt

### DIFF
--- a/src/cli/strategies/git-cz.js
+++ b/src/cli/strategies/git-cz.js
@@ -41,6 +41,7 @@ function gitCz (rawGitArgs, environment, adapterConfig) {
   let resolvedAdapterConfigPath = resolveAdapterPath(adapterConfig.path);
   let resolvedAdapterRootPath = findRoot(resolvedAdapterConfigPath);
   let prompter = getPrompter(adapterConfig.path);
+  let shouldStageAllFiles = rawGitArgs.includes('-a') || rawGitArgs.includes('--all');
 
   isClean(process.cwd(), function (error, stagingIsClean) {
     if (error) {
@@ -67,6 +68,6 @@ function gitCz (rawGitArgs, environment, adapterConfig) {
         throw error;
       }
     });
-  });
+  }, shouldStageAllFiles);
 
 }

--- a/src/commitizen/staging.js
+++ b/src/commitizen/staging.js
@@ -5,8 +5,8 @@ export { isClean };
 /**
  * Asynchrounously determines if the staging area is clean
  */
-function isClean (repoPath, done) {
-  exec('git diff --no-ext-diff --name-only && git diff --no-ext-diff --cached --name-only', {
+function isClean (repoPath, done, stageAllFiles) {
+  exec(`git diff --cached --no-ext-diff --name-only ${!!stageAllFiles ? '&& git diff --no-ext-diff --name-only' : ''}`, {
     maxBuffer: Infinity,
     cwd: repoPath
   }, function (error, stdout) {

--- a/test/tests/staging.js
+++ b/test/tests/staging.js
@@ -78,6 +78,43 @@ describe('staging', function () {
     });
   });
 
+  it('should determine if --all flag adds files to staging area', function (done) {
+
+    this.timeout(config.maxTimeout); // this could take a while
+
+    // SETUP
+
+    // Describe a repo and some files to add and commit
+    let repoConfig = {
+      path: config.paths.endUserRepo,
+      files: {
+        dummyfile: {
+          contents: `duck-duck-gray-duck`,
+          filename: `mydummiestfile.txt`,
+        },
+        gitignore: {
+          contents: `node_modules/`,
+          filename: `.gitignore`
+        }
+      }
+    };
+
+    gitInit(repoConfig.path);
+
+    staging.isClean(repoConfig.path, function (stagingIsCleanError, stagingIsClean) {
+      expect(stagingIsCleanError).to.be.null;
+      expect(stagingIsClean).to.be.true;
+
+      writeFilesToPath(repoConfig.files, repoConfig.path);
+
+      staging.isClean(repoConfig.path, function (afterWriteStagingIsCleanError, afterWriteStagingIsClean) {
+        expect(afterWriteStagingIsCleanError).to.be.null;
+        expect(afterWriteStagingIsClean).to.be.true;
+
+        done();
+      });
+    }, true);
+  });
 });
 
 afterEach(function () {


### PR DESCRIPTION
Fixes *#785* and *#585* (since the cause of these issues was related)

### Changes
* Checks the staging area prior to spawning the prompt when running `git-cz`,
* If no files are present in the staging area (prior to running `git-cz` command) throw "No files added to staging!" error ,
* Preserve the functionality of the `git -a` flag (`--all`) - running `git-cz --all` should add all the changed files to the staging area prior to spawning the prompt (no error thrown),
* Provided the necessary set tests for this change.

### Checklist
After the changes I ensured that:
 * no stylistic or unwanted errors are present (by following the conventions described in the CONTRIBUTING.md),
 * no tests are failing, by running `npm run test`,
 * build passes with no issues, by running `npm run build`,
 * checked the build output locally by:
   * initializing a new npm & git repository (`mkdir test && cd test && npm init -y && git init`),
   * locally built the `cz-cli` package by running `npm run build`, from within *cz-cli* directory,
   * made a few changes in the dummy project files,
   * run the command `node /path/to/cz-cli/project/bin/git-cz` (with and without `—all` flag, in different case scenarios),
   * ensured everything works as expected.

### Done
- [x] Added/updated unit tests for this change
- [x] Included links to related issues/PRs