### PR TITLE
fix: do not include .nyc_output in published files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,4 @@ test/tools/trigger-appveyor-tests.sh
 /appveyor.yml
 jsconfig.json
 travis_after_all.py
+/.nyc_output


### PR DESCRIPTION
I noticed in a PR review for a bump from 4.2.3 to 4.2.4 that there were
[810 changed files][1]. One was packages.json, the other 809 were
.nyc_output json files. This makes it particularly tough to do a
thorough security review.

[1]: https://app.renovatebot.com/package-diff?name=commitizen&from=4.2.3&to=4.2.4#d2h-425221

fixes #730