### PR TITLE
docs: fix invalid json format

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ For `husky` users, add the following configuration to the project's `package.jso
 ```json
 "husky": {
   "hooks": {
-    "prepare-commit-msg": "exec < /dev/tty && git cz --hook || true",
+    "prepare-commit-msg": "exec < /dev/tty && git cz --hook || true"
   }
 }
 ```


### PR DESCRIPTION
I found invalid json format on husky configurations, so I just fix it.
<img width="918" alt="スクリーンショット 2021-10-15 17 18 10" src="https://user-images.githubusercontent.com/12480170/137455659-f2b3dd47-93d2-4208-8c5b-8ad3f4f8f976.png">
