### PR TITLE
ci(release): defined a github workflow to release with semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+"on":
+  push:
+    branches:
+      - master
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          cache: npm
+          node-version: lts/*
+      - run: npm clean-install
+      - run: npx semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
re-enables the release automation that was lost with the cleanup of the `.travis.yml` in https://github.com/commitizen/cz-cli/pull/880. the `GITHUB_TOKEN` is provided automatically by the action and should have access to perform all necessary actions needed for the release. the `NPM_PUBLISH_TOKEN` would need to be made available as a secret to this action by a project maintainer.

this does not replace the verification that happens on Azure Pipelines and only runs on the `master` branch. it is assumed that changes are only ever merged after passing verification in a PR, so this workflow should be safe to implement independently from the existing verification pipelines.

this should unblock #914 and #897 (possibly more)