### PR TITLE
fix: fix the "isFunction" utility to match both "AsyncFunction"

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -38,7 +38,8 @@ function isFunction (functionToCheck) {
     return false;
   } else {
     var getType = {};
-    return functionToCheck && getType.toString.call(functionToCheck) === '[object Function]';
+    var functionType = getType.toString.call(functionToCheck);
+    return functionToCheck && (functionType === '[object Function]' || functionType === '[object AsyncFunction]');
   }
 }
 


### PR DESCRIPTION
fix: fix the "isFunction" utility to match both "AsyncFunction"

current behavior is the utility tries to match only "Function" and therefore "AsyncFunction" will be
considered bad and error will be thrown

fix #926