### PR TITLE
Allow minor and patch updates to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,20 +73,20 @@
     "uuid": "8.3.2"
   },
   "dependencies": {
-    "cachedir": "2.3.0",
-    "cz-conventional-changelog": "3.3.0",
-    "dedent": "0.7.0",
-    "detect-indent": "6.1.0",
+    "cachedir": "^2.3.0",
+    "cz-conventional-changelog": "^3.3.0",
+    "dedent": "~0.7.0",
+    "detect-indent": "^6.1.0",
     "find-node-modules": "^2.1.2",
-    "find-root": "1.1.0",
-    "fs-extra": "9.1.0",
-    "glob": "7.2.3",
-    "inquirer": "8.2.5",
-    "is-utf8": "^0.2.1",
-    "lodash": "4.17.21",
-    "minimist": "1.2.7",
-    "strip-bom": "4.0.0",
-    "strip-json-comments": "3.1.1"
+    "find-root": "^1.1.0",
+    "fs-extra": "^9.1.0",
+    "glob": "^7.2.3",
+    "inquirer": "^8.2.5",
+    "is-utf8": "~0.2.1",
+    "lodash": "^4.17.21",
+    "minimist": "^1.2.7",
+    "strip-bom": "^4.0.0",
+    "strip-json-comments": "^3.1.1"
   },
   "nyc": {
     "extends": "@istanbuljs/nyc-config-babel",


### PR DESCRIPTION
Currently most of the dependencies in this package are pinned to specific versions. This prevents consuming applications from being able to update these dependencies. This is particularly a problem when security vulnerabilities are found in dependencies, resulting in new versions of commitizen needing to be released i.e:

https://github.com/commitizen/cz-cli/issues/963
https://github.com/commitizen/cz-cli/issues/945
https://github.com/commitizen/cz-cli/issues/931
https://github.com/commitizen/cz-cli/issues/883

By using a `^` before the version number, consuming applications will be able to install minor and patch updates of `commitizen`'s dependencies, which should still be compatible with `commitizen` according to semver principles.