### PR TITLE
ci(build.yml): add pnpm installation to azure pipeline

### DIFF
--- a/jobs/build.yml
+++ b/jobs/build.yml
@@ -24,6 +24,10 @@ jobs:
       versionSpec: $(node_version)
   - script: git config --global user.email "example@example.com"
   - script: git config --global user.name "Example Git User"
+  - script: |
+      curl -f https://get.pnpm.io/v6.16.js | node - add --global pnpm@6
+      pnpm config set store-dir $(pnpm_config_cache)
+    displayName: "Setup pnpm"
   - script: npm install
   - script: npm run build
   - script: npm test && npm run write-coverage


### PR DESCRIPTION
Azure pipeline wasn't updated after adding pnpm support, see this [PR](https://github.com/commitizen/cz-cli/pull/915#issuecomment-1397599752).

I used [this snippet](https://pnpm.io/continuous-integration#azure-pipelines) from the official site.
To support compatibility with Node.js 12 we need to use [pnpm@6](https://pnpm.io/installation#compatibility).

Related: #915.