### PR TITLE
fix: process does not terminate after creating a commit with the --re…

### DIFF
--- a/src/cli/strategies/git-cz.js
+++ b/src/cli/strategies/git-cz.js
@@ -67,6 +67,7 @@ function gitCz (rawGitArgs, environment, adapterConfig) {
       if (error) {
         throw error;
       }
+      process.exit();
     });
   }, shouldStageAllFiles);
 

--- a/src/cli/strategies/git-cz.js
+++ b/src/cli/strategies/git-cz.js
@@ -67,7 +67,7 @@ function gitCz (rawGitArgs, environment, adapterConfig) {
       if (error) {
         throw error;
       }
-      process.exit();
+      process.exit(0);
     });
   }, shouldStageAllFiles);
 


### PR DESCRIPTION
### Problem:
The problem appears when the user creates a commit with the `--retry` option.

When creating a commit without this parameter, the process will be completed by a function that acts as a `prompt`, since without this parameter this function is not executed because the data is taken from the cache, the process was not completed.

Therefore, a line was added that terminates the process in case there was no error.
