### PR TITLE
chore(deps): update glob dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "find-node-modules": "^2.1.2",
     "find-root": "1.1.0",
     "fs-extra": "9.1.0",
-    "glob": "7.2.3",
+    "glob": "9.3.5",
     "inquirer": "8.2.5",
     "is-utf8": "^0.2.1",
     "lodash": "4.17.21",


### PR DESCRIPTION
This PR upgrades the glob package to address deprecation warnings in our dependencies. Key points:

Current version: Deprecated
Latest version: 11.x
Compatibility:
- Version 10.x: Tests fail
- Version 11.x: Tests fail
- Version 9.x: Tests pass and is still supported