### PR TITLE
fix: Close process after retry commit. Closes #974

### DIFF
--- a/src/cli/strategies/git-cz.js
+++ b/src/cli/strategies/git-cz.js
@@ -67,6 +67,7 @@ function gitCz (rawGitArgs, environment, adapterConfig) {
       if (error) {
         throw error;
       }
+      process.exit(0);
     });
   }, shouldStageAllFiles);
 


### PR DESCRIPTION
Closes #974 because the CI job for it is gone. This should kick off CI.