### PR TITLE
feat(adapter resolver): resolve '~' to HOME directory

### DIFF
--- a/src/commitizen/adapter.js
+++ b/src/commitizen/adapter.js
@@ -1,6 +1,7 @@
 import childProcess from 'child_process';
 import path from 'path';
 import fs from 'fs';
+import os from 'os';
 import findNodeModules from 'find-node-modules';
 import _ from 'lodash';
 import detectIndent from 'detect-indent';
@@ -152,6 +153,16 @@ function getPrompter (adapterPath) {
 }
 
 /**
+ * Expands a path that starts with ~ to the user's home directory
+ */
+function expandHome(p) {
+  if (p.startsWith("~/")) {
+    return path.join(os.homedir(), p.slice(1));
+  }
+  return p;
+}
+
+/**
  * Given a resolvable module name or path, which can be a directory or file, will
  * return a located adapter path or will throw.
  */
@@ -162,7 +173,7 @@ function resolveAdapterPath (inboundAdapterPath) {
 
   // Resolve from the root of the git repo if inboundAdapterPath is a path
   let absoluteAdapterPath = isPath ?
-    path.resolve(getGitRootPath(), inboundAdapterPath) :
+    path.resolve(getGitRootPath(), expandHome(inboundAdapterPath)) :
     inboundAdapterPath;
 
   try {

--- a/test/tests/adapter.js
+++ b/test/tests/adapter.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 import path from 'path';
 
 // TODO: augment these tests with tests using the actual cli call
@@ -101,6 +101,45 @@ describe('adapter', function () {
     expect(function () { adapter.resolveAdapterPath('IAMANIMPOSSIBLEPATH'); }).to.throw(Error);
     expect(function () { adapter.resolveAdapterPath(adapterConfig.path); }).not.to.throw(Error);
     expect(function () { adapter.resolveAdapterPath(path.join(adapterConfig.path, 'index.js')); }).not.to.throw(Error);
+  });
+
+  it('resolves adapter path started with ~', function () {
+
+    this.timeout(config.maxTimeout); // this could take a while
+
+    // SETUP
+
+    // Describe a repo and some files to add and commit
+    let repoConfig = {
+      path: config.paths.endUserRepo,
+      files: {
+        dummyfile: {
+            contents: `duck-duck-goose`,
+            filename: `mydummyfile.txt`,
+        },
+        gitignore: {
+          contents: `node_modules/`,
+          filename: `.gitignore`
+        }
+      }
+    };
+
+    // Describe an adapter
+    let adapterConfig = {
+      path: path.join(repoConfig.path, '/node_modules/@commitizen/cz-conventional-changelog'),
+      npmName: '@commitizen/cz-conventional-changelog'
+    };
+    adapterConfig.path = adapterConfig.path.replace(process.env.HOME, '~');
+    assert(adapterConfig.path.startsWith('~'), 'adapterConfig.path should start with ~');
+
+    // TEST
+
+    expect(function () { adapter.resolveAdapterPath('~/non/existent/path'); }).to.throw(Error);
+    expect(function () { adapter.resolveAdapterPath(adapterConfig.path); }).not.to.throw(Error);
+
+    expect(adapter.resolveAdapterPath(adapterConfig.path)).to.equal(
+      path.join(repoConfig.path, '/node_modules/@commitizen/cz-conventional-changelog/index.js')
+    );
   });
 
   it.skip('gets adapter prompter functions', function () {


### PR DESCRIPTION
This PR adds the support for `~` for the path property in the configuration file.

**Use case**

I install all my global dependencies with [Mise](https://mise.jdx.dev/) to have the same environment on my different computers. This causes `require("cz-emoji")` to not work.

So I have to specify the path of the dependency manually.

```json
{ "path": "/Users/arthur-fontaine/.local/share/mise/installs/npm-cz-emoji/latest/lib/node_modules/cz-emoji" }
```

This works, but as specified above, I want to have the same environment on my different computers, which have different usernames (on my computer 1, the home path is `/Users/arthur-fontaine`, and on my computer 2, this is `/Users/arthurfontaine`). So I tried to replace the absolute home path with `~` as follows.

```json
{ "path": "~/.local/share/mise/installs/npm-cz-emoji/latest/lib/node_modules/cz-emoji" }
```

But it didn't work. This PR makes it work!