### PR TITLE
fix(ci): fix pipelines and update matrices to node 18/20/22

### DIFF
--- a/jobs/build.yml
+++ b/jobs/build.yml
@@ -24,12 +24,13 @@ jobs:
       versionSpec: $(node_version)
   - script: git config --global user.email "example@example.com"
   - script: git config --global user.name "Example Git User"
-  - script: npm install -g pnpm
+  - script: npm install -g pnpm@9
     displayName: "Setup pnpm"
   - script: npm install
   - script: npm run build
   - script: npm test && npm run write-coverage
   - script: bash logo/generate.sh
+    condition: eq(variables['Agent.OS'], 'Linux')
   - task: PublishTestResults@2
     displayName: 'Publish Test Results'
     inputs:

--- a/jobs/build.yml
+++ b/jobs/build.yml
@@ -24,9 +24,7 @@ jobs:
       versionSpec: $(node_version)
   - script: git config --global user.email "example@example.com"
   - script: git config --global user.name "Example Git User"
-  - script: |
-      curl -f https://get.pnpm.io/v6.16.js | node - add --global pnpm@6
-      pnpm config set store-dir $(pnpm_config_cache)
+  - script: npm install -g pnpm
     displayName: "Setup pnpm"
   - script: npm install
   - script: npm run build

--- a/jobs/build.yml
+++ b/jobs/build.yml
@@ -11,12 +11,12 @@ jobs:
   strategy:
     maxParallel: 3
     matrix:
-      node-16:
-        node_version: ^16.13.0
-      node-14:
-        node_version: ^14.18.0
-      node-12:
-        node_version: ^12.6.0
+      node-22:
+        node_version: ^22.11.0
+      node-20:
+        node_version: ^20.9.0
+      node-18:
+        node_version: ^18.12.0
   steps:
   - task: NodeTool@0
     displayName: " Install Node.js"

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": ">= 12"
+    "node": ">= 18"
   },
   "collective": {
     "type": "opencollective",

--- a/src/git/whatChanged.js
+++ b/src/git/whatChanged.js
@@ -3,10 +3,11 @@ import { exec } from 'child_process';
 export { whatChanged };
 
 /**
- * Asynchronously gets the git whatchanged output
+ * Asynchronously gets the git log raw output (formerly `git whatchanged`,
+ * which modern git refuses to run without `--i-still-use-this`).
  */
 function whatChanged (repoPath, done) {
-  exec('git whatchanged', {
+  exec('git log --raw --no-merges', {
     maxBuffer: Infinity,
     cwd: repoPath
   }, function (error, stdout, stderr) {


### PR DESCRIPTION
Modern git refuses to run `git whatchanged` without `--i-still-use-this`, causing every CI build to fail in the test step and blocking all PRs. Switch to the equivalent `git log --raw --no-merges` that git itself suggests as the replacement; raw output format is unchanged so existing consumers continue to work.