### PR TITLE
ci(release): bump actions/checkout and actions/setup-node to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,8 @@ jobs:
     name: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           cache: npm
           node-version: lts/*


### PR DESCRIPTION
The release workflow currently uses `actions/checkout@v2` and `actions/setup-node@v2`. Both run on the long-deprecated Node 16 action runtime, and `setup-node@v2` talks to GitHub's v1 cache service, which now returns HTTP 400 — failing the release job before it can run `npx semantic-release`.

Bump both to v4 (current). No other changes needed.