### PR TITLE
ci(release): use npm trusted publishing via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,19 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           cache: npm
           node-version: lts/*
+      - run: npm install -g npm@latest
       - run: npm clean-install
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
## Summary

The release workflow currently fails to publish to npm because it still authenticates with `NPM_TOKEN` instead of using the trusted publishing (OIDC) configuration set up on npmjs.com. See the failing run: https://github.com/commitizen/cz-cli/actions/runs/27391262960/job/80976026728

Three things were needed to make OIDC actually take over:

- **Grant `id-token: write`** on the job so GitHub Actions can mint the OIDC token npm exchanges for a short-lived publish credential. `contents`/`issues`/`pull-requests: write` are also added because semantic-release pushes tags, creates GitHub releases, and comments on released PRs/issues.
- **Upgrade npm** to a version that supports trusted publishing (`>= 11.5.1`). `actions/setup-node@v4` with `node-version: lts/*` currently ships npm 10.x, which silently falls back to token auth.
- **Drop `NPM_TOKEN`** from the env. `@semantic-release/npm` uses the token whenever it is present, so OIDC was never being attempted even after trusted publishing was configured on the registry side.

## Test plan

- [x] Merge to `master` and confirm the next release run authenticates via OIDC (look for `npm notice` lines about provenance / trusted publishing instead of a token-auth step).
- [x] Confirm the published version on npm shows the provenance badge.